### PR TITLE
Hotfix 9.0.8: Correct Outdoor Temp logic (Raw-55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [9.0.8] - 2026-02-11
+
+### Fixed
+- **Outdoor Temperature**: Changed logic for 8888-port devices to subtract 55 from the raw value and use Celsius units, matching the behavior of 2878-port devices.
+
 ## [9.0.7] - 2026-02-11
 
 ### Added

--- a/custom_components/climate_ip/manifest.json
+++ b/custom_components/climate_ip/manifest.json
@@ -13,5 +13,5 @@
     "requests>=2.21.0",
     "xmltodict>=0.13.0"
   ],
-  "version": "9.0.7"
+  "version": "9.0.8"
 }

--- a/custom_components/climate_ip/samsungrac.yaml
+++ b/custom_components/climate_ip/samsungrac.yaml
@@ -181,12 +181,12 @@ device:
         {% if 'Mode' in device_state and 'options' in device_state['Mode'] -%}
           {% for option in device_state['Mode']['options'] -%}
             {% if 'OutdoorTemp_' in option -%}
-              {{ option.split('_')[1] }}
+              {{ (option.split('_')[1] | int) - 55 }}
             {%- endif %}
           {%- endfor %}
         {%- endif %}
       device_class: "temperature"
-      unit_of_measurement: "°F"
+      unit_of_measurement: "°C"
       validation_template: "{% if 'Mode' in device_state and 'options' in device_state['Mode'] %}valid{% endif %}"
 
     filter_clean_alarm:


### PR DESCRIPTION
### Fixed
- **Outdoor Temperature**: Changed logic for 8888-port devices to subtract 55 from the raw value and use Celsius units, matching the behavior of 2878-port devices.