### PR TITLE
Release v9.0.12 – Native temperature units, decimal fix & connection stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [9.0.12] - Unreleased
+
+### Added
+- **Independent Native Temperature Units**: Added two separate configuration options (`Native Current Temperature Unit` and `Native Target Temperature Unit`) accessible from the integration's Options Flow. This allows devices that report temperatures in Fahrenheit to be correctly converted and displayed in the Home Assistant global unit (Celsius or Fahrenheit), independently for current and target temperatures. New constants `CONF_TEMP_NATIVE_CURRENT` and `CONF_TEMP_NATIVE_TARGET` added to `const.py`.
+
+### Fixed
+- **Connection Stability**: Fixed a critical bug in `protocol_8888.py` (RAW connection engine) where a missing `Content-Length` header from the AC would cause the raw socket read fallback loop to hang indefinitely, triggering 30-second `Transient connection failure` timeouts in Home Assistant. The read loop now uses an absolute 5.0-second deadline via `asyncio.wait_for` to guarantee execution.
+- **Temperature Display**: Fixed a decimal precision bug in the Home Assistant thermostat card where fractional temperatures (e.g. `20.56°C`) were shown instead of integers. Fixed by explicitly rounding in `convert_dev_to_hass` in `properties.py` and overriding `temperature_unit` in `climate.py` to prevent Home Assistant frontend from applying secondary floating-point conversions. Core climate attributes are also filtered from `extra_state_attributes` to prevent raw values silently overwriting the rounded integers.
+- **Switch Validation**: Fixed a bug in `controller_yaml.py` where `device_state` passed to switch `validation_template` was incorrectly typed as a `ClimateIPDeviceState` object instead of a raw dictionary, causing `purify` and `auto_clean` switches to always fail validation and not appear in Home Assistant.
+- **YAML Config**: Added `validation_template` to all switches in `samsung_2878.yaml` and `samsungrac.yaml` to correctly hide controls not supported by the device.
+- **Logs**: Fixed `beep` (and other unsupported switches) triggering spurious state auto-correction warnings by ensuring properties failing validation are skipped during post-update discrepancy checks.
+- **Log Cleanup**: Removed verbose `DEBUG` log statements across `switch.py`, `sensor.py`, `samsung_2878.py`, `controller_yaml.py`, and `properties.py` to reduce log noise.
+
 ## [9.0.11] - 2026-02-17
 
 ### Fixed

--- a/custom_components/climate_ip/climate.py
+++ b/custom_components/climate_ip/climate.py
@@ -21,8 +21,8 @@ from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_MAC,
     CONF_NAME,
-    CONF_TEMPERATURE_UNIT,
     CONF_TOKEN,
+    PRECISION_WHOLE,
     STATE_OFF,
     STATE_ON,
 )
@@ -75,7 +75,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONFIG_DEVICE_NAME): cv.string,
         vol.Optional(CONF_CERT, default=DEFAULT_CONF_CERT_FILE): cv.string,
         vol.Optional(CONF_CONFIG_FILE, default=DEFAULT_CONF_CONFIG_FILE): cv.string,
-        vol.Optional(CONF_TEMPERATURE_UNIT, default=DEFAULT_CONF_TEMP_UNIT): cv.string,
         vol.Optional(CONF_CONTROLLER, default=DEFAULT_CONF_CONTROLLER): cv.string,
         vol.Optional(CONF_DEBUG, default=False): cv.boolean,
         vol.Optional(CONFIG_DEVICE_POLL, default=""): cv.string,
@@ -200,12 +199,16 @@ class ClimateIP(CoordinatorEntity[SamsungClimateCoordinator], ClimateEntity):
         self._supported_features = features
 
         # Set the temperature step from the configuration.
-        self._attr_target_temperature_step = self._config.get(CONF_TEMP_STEP, 1.0)
+        # We try to cast it to an integer if it's a whole number (e.g. 1 instead of 1.0) 
+        # to encourage the UI to drop `.0` decimals.
+        step = self._config.get(CONF_TEMP_STEP, 1.0)
+        self._attr_target_temperature_step = int(step) if step == int(step) else step
+        self._attr_precision = PRECISION_WHOLE
 
         # Initialize all state attributes to prevent AttributeError on startup.
         self._attr_hvac_mode: HVACMode | None = None
         self._attr_target_temperature: float | None = None
-        self._attr_current_temperature: float | None = None
+        self._attr_current_temperature: int | float | None = None
         self._attr_fan_mode: str | None = None
         self._attr_swing_mode: str | None = None
         self._attr_preset_mode: str | None = None
@@ -253,7 +256,9 @@ class ClimateIP(CoordinatorEntity[SamsungClimateCoordinator], ClimateEntity):
         if state:
             self._attr_hvac_mode = state.hvac_mode or HVACMode.OFF
             self._attr_target_temperature = state.target_temperature
-            self._attr_current_temperature = state.current_temperature # Also sync current temperature
+            
+            # Use raw current temperature, allowing HA PRECISION_WHOLE to handle frontend formatting
+            self._attr_current_temperature = state.current_temperature
             self._attr_fan_mode = state.fan_mode
             self._attr_swing_mode = state.swing_mode
             self._attr_preset_mode = state.preset_mode
@@ -444,21 +449,26 @@ class ClimateIP(CoordinatorEntity[SamsungClimateCoordinator], ClimateEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        return self.coordinator.state_attributes
+        # Core properties must be filtered out because HA merges extra_state_attributes 
+        # overwriting the core entity properties, which breaks any formatting or rounding 
+        # applied by the getters.
+        core_attrs = {
+            ATTR_TEMPERATURE, ATTR_CURRENT_TEMPERATURE, 
+            ATTR_HVAC_MODE, ATTR_FAN_MODE, ATTR_SWING_MODE, ATTR_PRESET_MODE
+        }
+        return {
+            k: v for k, v in self.coordinator.state_attributes.items() 
+            if k not in core_attrs
+        }
 
     @property
     def temperature_unit(self):
         """Return the temperature unit."""
-        # --- INICIO DE LA MODIFICACIÓN ---
-        # Priorizar la unidad del sensor de temperatura actual si está definida.
-        # Esto permite que el YAML anule la unidad de toda la entidad.
-        current_temp_prop = self.coordinator.get_property_object(ATTR_CURRENT_TEMPERATURE)
-        if current_temp_prop and current_temp_prop.unit_of_measurement:
-            # La propiedad ya contiene la constante de HA (p. ej., UnitOfTemperature.FAHRENHEIT)
-            return current_temp_prop.unit_of_measurement
-        # Caer de nuevo al valor por defecto del controlador si no hay una unidad específica.
-        return self.coordinator.temperature_unit
-        # --- FIN DE LA MODIFICACIÓN ---
+        # Force HA to recognize that all temperature properties returned by the entity
+        # are ALREADY in the HA global display unit (e.g. Celsius). 
+        # This prevents the frontend from applying secondary floating-point math
+        # conversions (like (F-32)*5/9) over our integers.
+        return self.hass.config.units.temperature_unit
 
     @property
     def current_temperature(self):

--- a/custom_components/climate_ip/config_flow.py
+++ b/custom_components/climate_ip/config_flow.py
@@ -10,10 +10,14 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
-    NumberSelector,
+    NumberSelector,         # Keep NumberSelector locally if needed elsewhere, though we replace it for poll interval
     NumberSelectorMode,
     NumberSelectorConfig,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
 )
+import datetime
 import homeassistant.helpers.config_validation as cv
 from getmac import get_mac_address
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -22,6 +26,7 @@ from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_MAC,
     CONF_TOKEN,
+    UnitOfTemperature,
 )
 from homeassistant.core import callback
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -40,10 +45,16 @@ from .const import (
     CONF_CONFIG_FILE,
     CONF_DEVICE_ID,
     CONF_DEVICES,
+    DEFAULT_CONF_CERT_FILE,
+    DEFAULT_CONF_CONFIG_FILE,
+    DEFAULT_CONF_TEMP_UNIT,
+    DEFAULT_CONF_CONTROLLER,
     CONF_DISCOVERED_DEVICES,
     CONF_SELECTED_DEVICES,
     CONF_DEVICE_TYPE,
     DEVICE_TYPE_MIM_H03,
+    CONF_TEMP_NATIVE_CURRENT,
+    CONF_TEMP_NATIVE_TARGET,
     # --- START OF MODIFICATION (Milestone 4) ---
     DEVICE_TYPE_8888_GROUP,
     # --- START OF MODIFICATION (Milestone 4) ---
@@ -268,18 +279,29 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow):
             vol.Optional(CONF_TOKEN, default=self.flow_data.get(CONF_TOKEN, "")): str,
             vol.Optional(CONF_CERT, default=self.flow_data.get(CONF_CERT, "")): str,
             vol.Optional(
-                CONF_POLL_INTERVAL, default=self.flow_data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
-            ): NumberSelector(
-                NumberSelectorConfig(
-                    min=MIN_POLL_INTERVAL,
-                    max=MAX_POLL_INTERVAL,
-                    unit_of_measurement="seconds",
-                    mode=NumberSelectorMode.BOX,
-                )
+                CONF_POLL_INTERVAL, default=str(datetime.timedelta(seconds=self.flow_data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)))
+            ): TextSelector(
+                TextSelectorConfig(type=TextSelectorType.TEXT)
             ),
             vol.Optional(
                 CONF_ENABLE_POLLING, default=self.flow_data.get(CONF_ENABLE_POLLING, DEFAULT_ENABLE_POLLING)
             ): bool,
+            vol.Optional(
+                CONF_TEMP_NATIVE_CURRENT, default=self.flow_data.get(CONF_TEMP_NATIVE_CURRENT, DEFAULT_CONF_TEMP_UNIT)
+            ): SelectSelector(
+                SelectSelectorConfig(
+                    options=[UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT],
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(
+                CONF_TEMP_NATIVE_TARGET, default=self.flow_data.get(CONF_TEMP_NATIVE_TARGET, DEFAULT_CONF_TEMP_UNIT)
+            ): SelectSelector(
+                SelectSelectorConfig(
+                    options=[UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT],
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            ),
         })
         return vol.Schema(schema_dict)
 
@@ -299,6 +321,30 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow):
                     data_schema=self._get_samsung_2878_schema(mac_required=(error_reason == "mac_resolve_failed")),
                     errors=errors,
                 )
+
+            # Validate polling interval
+            if CONF_POLL_INTERVAL in user_input:
+                try:
+                    val = user_input[CONF_POLL_INTERVAL]
+                    if isinstance(val, (int, float)):
+                        seconds = int(val)
+                    else:
+                        time_period = cv.time_period_str(str(val))
+                        seconds = int(time_period.total_seconds())
+
+                    if seconds < MIN_POLL_INTERVAL:
+                        raise vol.Invalid(f"Minimum interval is {MIN_POLL_INTERVAL} seconds")
+                    if seconds > MAX_POLL_INTERVAL:
+                        raise vol.Invalid(f"Maximum interval is {MAX_POLL_INTERVAL} seconds")
+                    
+                    self.flow_data[CONF_POLL_INTERVAL] = seconds
+                except (vol.Invalid, ValueError):
+                    errors[CONF_POLL_INTERVAL] = "invalid_poll_interval"
+                    return self.async_show_form(
+                        step_id="samsung_2878",
+                        data_schema=self._get_samsung_2878_schema(),
+                        errors=errors,
+                    )
 
             # Standardize the name to ensure consistency
             if not self.flow_data.get(CONF_NAME):
@@ -346,13 +392,24 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow):
             vol.Optional(CONF_TOKEN, default=""): str,
             vol.Optional(CONF_CERT, default="ac14k_m.pem"): str,
             vol.Optional(
-                CONF_POLL_INTERVAL, default=self.flow_data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
-            ): NumberSelector(
-                NumberSelectorConfig(
-                    min=MIN_POLL_INTERVAL,
-                    max=MAX_POLL_INTERVAL,
-                    unit_of_measurement="seconds",
-                    mode=NumberSelectorMode.BOX,
+                CONF_POLL_INTERVAL, default=str(datetime.timedelta(seconds=self.flow_data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)))
+            ): TextSelector(
+                TextSelectorConfig(type=TextSelectorType.TEXT)
+            ),
+            vol.Optional(
+                CONF_TEMP_NATIVE_CURRENT, default=self.flow_data.get(CONF_TEMP_NATIVE_CURRENT, DEFAULT_CONF_TEMP_UNIT)
+            ): SelectSelector(
+                SelectSelectorConfig(
+                    options=[UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT],
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            ),
+            vol.Optional(
+                CONF_TEMP_NATIVE_TARGET, default=self.flow_data.get(CONF_TEMP_NATIVE_TARGET, DEFAULT_CONF_TEMP_UNIT)
+            ): SelectSelector(
+                SelectSelectorConfig(
+                    options=[UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT],
+                    mode=SelectSelectorMode.DROPDOWN,
                 )
             ),
         })
@@ -374,6 +431,30 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow):
                     data_schema=self._get_samsung_8888_schema(mac_required=(error_reason == "mac_resolve_failed")),
                     errors=errors,
                 )
+
+            # Validate polling interval
+            if CONF_POLL_INTERVAL in user_input:
+                try:
+                    val = user_input[CONF_POLL_INTERVAL]
+                    if isinstance(val, (int, float)):
+                        seconds = int(val)
+                    else:
+                        time_period = cv.time_period_str(str(val))
+                        seconds = int(time_period.total_seconds())
+
+                    if seconds < MIN_POLL_INTERVAL:
+                        raise vol.Invalid(f"Minimum interval is {MIN_POLL_INTERVAL} seconds")
+                    if seconds > MAX_POLL_INTERVAL:
+                        raise vol.Invalid(f"Maximum interval is {MAX_POLL_INTERVAL} seconds")
+                    
+                    self.flow_data[CONF_POLL_INTERVAL] = seconds
+                except (vol.Invalid, ValueError):
+                    errors[CONF_POLL_INTERVAL] = "invalid_poll_interval"
+                    return self.async_show_form(
+                        step_id="samsung_8888",
+                        data_schema=self._get_samsung_8888_schema(),
+                        errors=errors,
+                    )
 
             if self.flow_data.get(CONF_TOKEN):
                 return await self._create_entry()
@@ -415,14 +496,9 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow):
         schema[vol.Required(CONF_TOKEN)] = str
         schema[vol.Optional(CONF_NAME)] = str
         schema[vol.Optional(
-            CONF_POLL_INTERVAL, default=self.flow_data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
-        )] = NumberSelector(
-            NumberSelectorConfig(
-                min=MIN_POLL_INTERVAL,
-                max=MAX_POLL_INTERVAL,
-                unit_of_measurement="seconds",
-                mode=NumberSelectorMode.BOX,
-            )
+            CONF_POLL_INTERVAL, default=str(datetime.timedelta(seconds=self.flow_data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)))
+        )] = TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT)
         )
         
         return vol.Schema(schema)
@@ -437,6 +513,35 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow):
             if device_type:
                 test_data[CONF_CONFIG_FILE] = DEVICE_TYPE_TO_CONFIG_FILE.get(device_type)
             
+            if device_type:
+                test_data[CONF_CONFIG_FILE] = DEVICE_TYPE_TO_CONFIG_FILE.get(device_type)
+            
+            # Validate polling interval before connection test
+            if CONF_POLL_INTERVAL in user_input:
+                try:
+                    val = user_input[CONF_POLL_INTERVAL]
+                    if isinstance(val, (int, float)):
+                        seconds = int(val)
+                    else:
+                        time_period = cv.time_period_str(str(val))
+                        seconds = int(time_period.total_seconds())
+
+                    if seconds < MIN_POLL_INTERVAL:
+                        raise vol.Invalid(f"Minimum interval is {MIN_POLL_INTERVAL} seconds")
+                    if seconds > MAX_POLL_INTERVAL:
+                        raise vol.Invalid(f"Maximum interval is {MAX_POLL_INTERVAL} seconds")
+                    
+                    self.flow_data[CONF_POLL_INTERVAL] = seconds
+                    # Update test_data as well if needed, though controller uses its own logic
+                    test_data[CONF_POLL_INTERVAL] = seconds
+                except (vol.Invalid, ValueError):
+                    errors[CONF_POLL_INTERVAL] = "invalid_poll_interval"
+                    return self.async_show_form(
+                        step_id="rest_api",
+                        data_schema=self._get_rest_api_schema(),
+                        errors=errors,
+                    )
+
             # --- START OF FIX: Cleanup controller ---
             controller = None
             try:
@@ -879,6 +984,32 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     data_schema=self._get_options_schema(),
                     errors={"base": "token_required_for_aiohttp"},
                 )
+            # Validate polling interval
+            if CONF_POLL_INTERVAL in user_input:
+                try:
+                    val = user_input[CONF_POLL_INTERVAL]
+                    # Attempt to parse using HA's time_period validator which handles ints and "hh:mm:ss"
+                    # If existing value is int, handle gracefully
+                    if isinstance(val, (int, float)):
+                        seconds = int(val)
+                    else:
+                        time_period = cv.time_period_str(str(val))
+                        seconds = int(time_period.total_seconds())
+
+                    if seconds < MIN_POLL_INTERVAL:
+                        raise vol.Invalid(f"Minimum interval is {MIN_POLL_INTERVAL} seconds")
+                    if seconds > MAX_POLL_INTERVAL:
+                        raise vol.Invalid(f"Maximum interval is {MAX_POLL_INTERVAL} seconds ({datetime.timedelta(seconds=MAX_POLL_INTERVAL)})")
+                    
+                    user_input[CONF_POLL_INTERVAL] = seconds
+
+                except (vol.Invalid, ValueError) as e:
+                    return self.async_show_form(
+                        step_id="init",
+                        data_schema=self._get_options_schema(),
+                        errors={CONF_POLL_INTERVAL: "invalid_poll_interval"},
+                    )
+
             return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
@@ -908,13 +1039,43 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             )
 
         # Get the current value for poll_interval from options, falling back to data, then to default.
-        current_interval = self.config_entry.options.get(
+        current_interval_seconds = self.config_entry.options.get(
             CONF_POLL_INTERVAL, self.config_entry.data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
         )
+        
+        # Convert to string representation for display (e.g. "0:01:00" for 60s)
+        # This makes it easy for the user to edit in hh:mm:ss format
+        current_interval_str = str(datetime.timedelta(seconds=int(current_interval_seconds)))
+
         schema_dict[vol.Required(
-            CONF_POLL_INTERVAL, default=current_interval
-        )] = NumberSelector(
-            NumberSelectorConfig(min=MIN_POLL_INTERVAL, max=MAX_POLL_INTERVAL, unit_of_measurement="seconds", mode=NumberSelectorMode.BOX)
+            CONF_POLL_INTERVAL, default=current_interval_str
+        )] = TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT)
+        )
+        
+
+        current_native_current_unit = self.config_entry.options.get(
+            CONF_TEMP_NATIVE_CURRENT, self.config_entry.data.get(CONF_TEMP_NATIVE_CURRENT, DEFAULT_CONF_TEMP_UNIT)
+        )
+        schema_dict[vol.Required(
+            CONF_TEMP_NATIVE_CURRENT, default=current_native_current_unit
+        )] = SelectSelector(
+            SelectSelectorConfig(
+                options=[UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        )
+
+        current_native_target_unit = self.config_entry.options.get(
+            CONF_TEMP_NATIVE_TARGET, self.config_entry.data.get(CONF_TEMP_NATIVE_TARGET, DEFAULT_CONF_TEMP_UNIT)
+        )
+        schema_dict[vol.Required(
+            CONF_TEMP_NATIVE_TARGET, default=current_native_target_unit
+        )] = SelectSelector(
+            SelectSelectorConfig(
+                options=[UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
         )
 
         current_enable_polling = self.config_entry.options.get(

--- a/custom_components/climate_ip/connection_aiohttp.py
+++ b/custom_components/climate_ip/connection_aiohttp.py
@@ -412,7 +412,7 @@ class ConnectionAiohttp8888(Connection):
         url_path: Optional[str],
         data: Optional[str],
         headers: Optional[Dict[str, str]],
-        _is_probe: bool = False, # Flag interno (ignorado en esta versión, pero mantenido por si acaso)
+        _is_probe: bool = False, # Internal flag (ignored in this version, but kept just in case)
         _is_poll: bool = False,
     ) -> Tuple[str, Optional[Dict[str, str]]]:
         """

--- a/custom_components/climate_ip/const.py
+++ b/custom_components/climate_ip/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["climate"]
 CONF_POLL_INTERVAL = "poll_interval"
 DEFAULT_POLL_INTERVAL = 60
 MIN_POLL_INTERVAL = 5
-MAX_POLL_INTERVAL = 300
+MAX_POLL_INTERVAL = 21600
 CONF_ENABLE_POLLING = "enable_polling"
 DEFAULT_ENABLE_POLLING = True
 
@@ -20,6 +20,8 @@ CONF_NAME = "name"
 CONF_SELECTED_DEVICES = "selected_devices"
 CONF_DEVICES = "devices"
 CONF_DEVICE_ID = "device_id"
+CONF_TEMP_NATIVE_CURRENT = "temp_native_current"
+CONF_TEMP_NATIVE_TARGET = "temp_native_target"
 
 # --- Connection Method Constants (for Dual Engine) ---
 CONF_CONN_METHOD = "connection_method"

--- a/custom_components/climate_ip/controller_yaml.py
+++ b/custom_components/climate_ip/controller_yaml.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_MAC,
     CONF_IP_ADDRESS,
-    CONF_TEMPERATURE_UNIT,
     CONF_TOKEN,
     STATE_ON,
     STATE_UNKNOWN,
@@ -67,6 +66,9 @@ from .const import (
     CONFIG_DEVICE_POLL,
     CONFIG_DEVICE_STATUS,
     CONFIG_DEVICE_CONNECTION_TYPE,
+    DEFAULT_CONF_TEMP_UNIT,
+    CONF_TEMP_NATIVE_CURRENT,
+    CONF_TEMP_NATIVE_TARGET,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -285,7 +287,7 @@ class YamlController(ClimateController):
 
         nodes = ac.get(CONFIG_DEVICE_OPERATIONS, {})
         for op_key in nodes.keys():
-            _LOGGER.debug("%s [ObjTrace] Creating property '%s'. Connection ID: %s, Prefix: %s", self.log_prefix, op_key, id(self._connection), self._connection.log_prefix)
+
             op = create_property(op_key, nodes[op_key], self._connection, self, self._state_getter)
             if op is not None:
                 self._operations[op.id] = op
@@ -295,30 +297,25 @@ class YamlController(ClimateController):
                 # --- END FIX ---
                 self._service_schema_map[vol.Optional(op.id)] = op.config_validation_type
 
-        # --- START OF MODIFICATION: Load separate switches section ---
         nodes = ac.get(CONFIG_DEVICE_SWITCHES, {})
-        _LOGGER.debug("%s Loading %d switches from 'switches' section...", self.log_prefix, len(nodes))
         for op_key in nodes.keys():
-             _LOGGER.debug("%s [ObjTrace] Creating switch property '%s'.", self.log_prefix, op_key)
-             # Switches are just operations with type='switch'. We use create_property which checks type.
-             op = create_property(op_key, nodes[op_key], self._connection, self, self._state_getter)
-             if op is not None:
-                 self._operations[op.id] = op
-                 # --- FIX: Populate _operations_list ---
-                 if op not in self._operations_list:
+            # Switches are just operations with type='switch'. We use create_property which checks type.
+            op = create_property(op_key, nodes[op_key], self._connection, self, self._state_getter)
+            if op is not None:
+                self._operations[op.id] = op
+                # --- FIX: Populate _operations_list ---
+                if op not in self._operations_list:
                     self._operations_list.append(op)
-                 # --- END FIX ---
-                 self._service_schema_map[vol.Optional(op.id)] = op.config_validation_type
+                # --- END FIX ---
+                self._service_schema_map[vol.Optional(op.id)] = op.config_validation_type
         # --- END OF MODIFICATION ---
 
         nodes = ac.get(CONFIG_DEVICE_ATTRIBUTES, {})
-        _LOGGER.debug("%s Loading %d attributes...", self.log_prefix, len(nodes))
         for key in nodes.keys():
-            _LOGGER.debug("%s Processing attribute '%s' from YAML", self.log_prefix, key)
             prop = create_property(key, nodes[key], self._connection, self, self._state_getter)
             if prop is not None:
                 self._properties[prop.id] = prop
-                # --- INICIO DE LA MODIFICACIÓN ---
+                # --- START OF MODIFICATION ---
                 # Add support for static 'unit_of_measurement' in attributes, same as in sensors.
                 has_setter = hasattr(prop, 'set_unit_of_measurement')
                 has_unit_key = 'unit_of_measurement' in nodes[key]
@@ -349,6 +346,57 @@ class YamlController(ClimateController):
                 self._sensors_list.append(name)
         # --- END OF ADDITION ---
         
+        # --- START OF MODIFICATION: Apply temperature unit from config/options ---
+        # Retrieve the Native temperature units from the config entry options (primary) or data (fallback)
+        # For the display unit, we use Home Assistant's global configured temperature unit
+        configured_unit = self.hass.config.units.temperature_unit if self.hass else DEFAULT_CONF_TEMP_UNIT
+        native_current_unit = DEFAULT_CONF_TEMP_UNIT
+        native_target_unit = DEFAULT_CONF_TEMP_UNIT
+
+        entry_id = self._config.get("entry_id")
+        if self.hass and entry_id:
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry:
+                native_current_unit = entry.options.get(CONF_TEMP_NATIVE_CURRENT, entry.data.get(CONF_TEMP_NATIVE_CURRENT, configured_unit))
+                native_target_unit = entry.options.get(CONF_TEMP_NATIVE_TARGET, entry.data.get(CONF_TEMP_NATIVE_TARGET, configured_unit))
+                _LOGGER.debug("%s [Init] Configured temperature units - Display (HA Global): %s, Native Current: %s, Native Target: %s", 
+                              self.log_prefix, configured_unit, native_current_unit, native_target_unit)
+        
+        # Helper function to apply unit
+        def apply_unit(prop):
+            if not prop: return
+            # Check if it's a temperature property or has device_class "temperature"
+            is_temp = False
+            if hasattr(prop, 'match_type') and prop.match_type("temperature"):
+                is_temp = True
+            elif prop.device_class == "temperature":
+                is_temp = True
+            
+            if is_temp:
+                if hasattr(prop, 'set_hass_unit') and hasattr(prop, 'set_device_unit'):
+                    _LOGGER.debug("%s Applying dual units to property '%s'. Display: %s", self.log_prefix, prop.id, configured_unit)
+                    prop.set_hass_unit(configured_unit)
+                    if prop.id == ATTR_TEMPERATURE:
+                        prop.set_device_unit(native_target_unit)
+                    else:
+                        prop.set_device_unit(native_current_unit)
+                elif hasattr(prop, 'set_unit_of_measurement'):
+                    _LOGGER.debug("%s Applying configured unit '%s' to property '%s'", self.log_prefix, configured_unit, prop.id)
+                    prop.set_unit_of_measurement(configured_unit)
+
+        # Iterate over all operations
+        for op in self._operations.values():
+            apply_unit(op)
+            
+        # Iterate over all attributes (properties)
+        for prop in self._properties.values():
+            apply_unit(prop)
+            
+        # Iterate over all sensors
+        for sensor in self._sensors.values():
+            apply_unit(sensor)
+        # --- END OF MODIFICATION ---
+
         self._operations_list = list(self._operations.keys())
         self._properties_list = list(self._properties.keys())
         self._is_fully_initialized = True
@@ -388,7 +436,7 @@ class YamlController(ClimateController):
             _LOGGER.error("%s YAML configuration is empty or could not be read.", self.log_prefix)
             return False
         # --- END OF FIX ---
-        # El parseo inicial usa el device_id actual (que puede ser None) como clave de cache.
+        # The initial parsing uses the current device_id (which can be None) as the cache key.
         partial_render_str = stream_wrapper(self._raw_yaml_config, self._token, self._ip_address, self._device_id)
         yaml_device = yaml.safe_load(partial_render_str)
         self._parsed_yaml_cache[self._device_id] = yaml_device
@@ -437,14 +485,7 @@ class YamlController(ClimateController):
 
         # This call will now create the correct connection type based on the logic above
         # --- START OF MODIFICATION (Milestone 3) ---
-        _LOGGER.debug(
-            "%s Calling create_connection. Session is valid: %s, HASS is valid: %s",
-            self.log_prefix, self._session is not None, self.hass is not None
-        )
-        _LOGGER.debug(
-            "%s Connection node being passed to create_connection: %s",
-            self.log_prefix, mask_sensitive_data(connection_node)
-        )
+
 
         # --- START: Logic moved from connection.py ---
         key = self.unique_id
@@ -685,7 +726,7 @@ class YamlController(ClimateController):
     @property
     def poll(self) -> Optional[bool]:
         """Return the polling state from the YAML configuration."""
-        _LOGGER.debug("%s Poll property accessed, returning: %s", self.log_prefix, self._poll)
+
         return self._poll
 
     async def async_update_properties_from_state(self, full_device_state: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -790,6 +831,10 @@ class YamlController(ClimateController):
 
         _LOGGER.debug("%s Checking for post-update state inconsistencies", self.log_prefix)
         for op_name, op in self._operations.items():
+            # Skip auto-correction for properties that are not supported by the device
+            if hasattr(op, 'is_valid') and not op.is_valid(device_to_process):
+                continue
+                
             if hasattr(op, 'values') and op.value is not None and op.value != STATE_UNKNOWN:
                 if op.value not in op.values:
                     new_value = op.values[0] if op.values else STATE_UNKNOWN
@@ -838,7 +883,6 @@ class YamlController(ClimateController):
             return {}
 
         reconstructed_state = copy.deepcopy(last_real_state)
-        _LOGGER.debug("%s [HASS->DEV] Rebuilding from real state template (deepcopied)", self.log_prefix)
 
         all_props = list(self._operations.values()) + list(self._properties.values())
 
@@ -853,14 +897,10 @@ class YamlController(ClimateController):
             # --- END OF FIX ---
 
             hass_value = getattr(hass_state, op.id, None)
-            _LOGGER.debug("%s [HASS->DEV] Prop: '%s', HASS Value: %s (type: %s)", self.log_prefix, op.id, hass_value, type(hass_value).__name__)
         
             if hass_value is not None:                
                 # This conversion is what matters for building the device state
                 device_value = op.convert_hass_to_dev(hass_value)
-                # --- START OF LOGGING ---
-                _LOGGER.debug("%s [HASS->DEV] Prop: '%s', Device Value: %s (type: %s)", self.log_prefix, op.id, device_value, type(device_value).__name__)
-                # --- END OF LOGGING ---
                 # Optimization: Use cached device key from template.
                 device_key = self._get_cached_device_key_from_prop(op) # Get the key like 'AC_FUN_OPMODE'
                 # --- START OF FIX: Ensure key exists before writing ---
@@ -869,10 +909,7 @@ class YamlController(ClimateController):
                     reconstructed_state[device_key] = device_value
                 # --- END OF FIX ---
                 
-        # --- START OF LOGGING ---
-        _LOGGER.debug("%s [HASS->DEV] Final reconstructed state: %s", self.log_prefix, str(reconstructed_state)[:200] + "...")
         return reconstructed_state
-        # --- END OF LOGGING ---
 
     async def _build_device_state_from_props(self) -> Optional[Dict[str, Any]]: # Used for prediction
         """
@@ -959,7 +996,6 @@ class YamlController(ClimateController):
         # Key not in cache, so we calculate and store it.
         key = self._get_device_key_from_template(prop.status_template)
         self._prop_template_key_cache[prop_id] = key
-        _LOGGER.debug("%s [Cache] Stored template key for '%s' -> '%s'", self.log_prefix, prop_id, key)
         return key
 
     def _get_device_key_from_template(self, template_obj: Any) -> Optional[str]:
@@ -986,10 +1022,6 @@ class YamlController(ClimateController):
         
         # If no match, it's likely a complex template. This is not an error,
         # so we log at debug level instead of warning to keep logs clean.
-        if any(keyword in template_string for keyword in ['if', 'else', 'for']):
-            _LOGGER.debug("%s [Regex] Template is complex, cannot auto-extract key. This is normal for templates with logic.", self.log_prefix)
-        else:
-            _LOGGER.debug("%s [Regex] Could not extract 'device_state' key from template: %s", self.log_prefix, template_string)
         return None
 
     async def async_predict_and_correct_state(self, current_hass_state: ClimateIPDeviceState, property_name: str, new_value: Any) -> Tuple[ClimateEntityFeature, Dict[str, Any]]:
@@ -1255,6 +1287,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_IP_ADDRESS): cv.string,
         vol.Optional(CONF_TOKEN): cv.string,
         vol.Optional(CONF_DEVICE_ID): cv.string,
-        vol.Optional(CONF_TEMPERATURE_UNIT, default=UnitOfTemperature.CELSIUS): cv.string,
+        vol.Optional(CONF_TEMP_NATIVE_CURRENT, default=DEFAULT_CONF_TEMP_UNIT): cv.string,
+        vol.Optional(CONF_TEMP_NATIVE_TARGET, default=DEFAULT_CONF_TEMP_UNIT): cv.string,
     }
 )

--- a/custom_components/climate_ip/manifest.json
+++ b/custom_components/climate_ip/manifest.json
@@ -13,5 +13,5 @@
     "requests>=2.21.0",
     "xmltodict>=0.13.0"
   ],
-  "version": "9.0.11"
+  "version": "9.0.12"
 }

--- a/custom_components/climate_ip/properties.py
+++ b/custom_components/climate_ip/properties.py
@@ -178,9 +178,7 @@ class DeviceProperty:
         """
         # Check if the provided unit is a known temperature unit and convert it.
         # This allows using "°F", "F", "Fahrenheit", etc., in YAML.
-        _LOGGER.debug("%s [set_unit_of_measurement] for '%s' received raw unit: '%s'", self.log_prefix, self.id, unit)
         converted_unit = UNIT_MAP.get(unit, unit)
-        _LOGGER.debug("%s [set_unit_of_measurement] for '%s' converted unit is: '%s' (type: %s)", self.log_prefix, self.id, converted_unit, type(converted_unit).__name__)
         self._unit_of_measurement = converted_unit
 
     def get_connection(self, value):
@@ -265,18 +263,6 @@ class GetJsonStatus(DeviceProperty):
         """Load the connection details from the 'status' node in YAML."""
         from jinja2 import Template
         
-        # --- START OF MODIFICATION: Topology Debugging ---
-        if self._connection:
-             _LOGGER.debug(
-                 "%s [Topology] GetJsonStatus.load_from_yaml: base connection ID=%s, type=%s, parent=%s",
-                 self.log_prefix, 
-                 id(self._connection), 
-                 type(self._connection).__name__,
-                 getattr(self._connection, "_parent", "N/A")
-             )
-        else:
-             _LOGGER.debug("%s [Topology] GetJsonStatus.load_from_yaml: base connection is None!", self.log_prefix)
-        # --- END OF MODIFICATION ---
         
         super_result = super().load_from_yaml(node)
 
@@ -321,7 +307,7 @@ class GetJsonStatus(DeviceProperty):
         # --- START OF MODIFICATION (Milestone 1) ---
         # Check if the connection is native async (aiohttp)
         if connection.is_async_native:
-            _LOGGER.debug("[Dual Engine] Executing 'async_execute' (Async Engine)")
+
             try:
                 # The connection_template contains the request parameters (method, url, etc.)
                 # We need to render it to get the JSON string of parameters.
@@ -329,12 +315,6 @@ class GetJsonStatus(DeviceProperty):
                     _LOGGER.error("%s [GetJsonStatus] Connection template is missing for async execution.", self.log_prefix)
                     return None
                 
-                # --- START OF MODIFICATION: Add logging ---
-                _LOGGER.debug(
-                    "%s [GetJsonStatus] Using connection template for async execution: %s",
-                    self.log_prefix,
-                    self.connection_template.template if hasattr(self.connection_template, 'template') else self.connection_template
-                )
                 
                 # Prepare render context with connection parameters (crucial for DUID in 2878)
                 render_context = {}
@@ -354,7 +334,7 @@ class GetJsonStatus(DeviceProperty):
                     elif hasattr(connection, 'config') and hasattr(connection.config, 'token') and connection.config.token:
                         render_context['token'] = connection.config.token
 
-                _LOGGER.debug("%s [GetJsonStatus] Render context keys: %s", self.log_prefix, list(render_context.keys()))
+
                 # --- END OF MODIFICATION ---
 
                 response_text = None
@@ -366,7 +346,7 @@ class GetJsonStatus(DeviceProperty):
                 except json.JSONDecodeError as decode_error:
                     # If response_text is None, it means we failed parsing params_str (likely XML for 2878)
                     if response_text is None:
-                        _LOGGER.debug("%s [GetJsonStatus] Params parsing failed (XML?), trying raw execution: %s", self.log_prefix, params_str)
+
                         # Execute raw command. For 2878, method/url/headers are ignored.
                         # Important: We must await this call to actually send the command.
                         # The return value for raw execute might be the response XML string.
@@ -407,7 +387,7 @@ class GetJsonStatus(DeviceProperty):
                 raise
         else:
             # It's a synchronous connection (requests or 2878)
-            _LOGGER.debug("[Dual Engine] Executing 'execute' in executor (Sync Engine)")
+
 
             # This is the logic that will run now, identical to the previous one.
             # The synchronous 'execute' call is wrapped in async_add_executor_job
@@ -472,7 +452,7 @@ class DeviceOperation(DeviceProperty):
 
         # --- START: Logic to handle async nested commands ---
         if connection.is_async_native:
-            _LOGGER.debug("[Dual Engine] Executing 'async_execute' (Async Engine)")
+
             try:
                 # The `async_execute` method in ConnectionAiohttp8888 will handle its embedded command internally.
                 # We just need to call it once with the parameters for the *main* command.                
@@ -531,7 +511,7 @@ class DeviceOperation(DeviceProperty):
                 return False
         # --- END: Logic to handle async nested commands ---
         else: # Fallback to original synchronous logic
-            _LOGGER.debug("[Dual Engine] Executing 'execute' in executor (Sync Engine)")
+
             try:
                 response = await self._controller.hass.async_add_executor_job(
                     connection.execute,
@@ -842,7 +822,20 @@ class TemperatureOperation(BasicNumericOperation):
     def __init__(self, name, connection, controller, status_getter=None):
         super(TemperatureOperation, self).__init__(name, connection, controller, status_getter)
         self._unit_template = None
-        self._unit = UnitOfTemperature.CELSIUS
+        self._device_unit = UnitOfTemperature.CELSIUS
+        self._hass_unit = UnitOfTemperature.CELSIUS
+
+    def set_device_unit(self, unit: str):
+        """Set the native unit used by the device."""
+        converted_unit = UNIT_MAP.get(unit, unit)
+        self._device_unit = converted_unit
+
+    def set_hass_unit(self, unit: str):
+        """Set the display unit used by Home Assistant."""
+        converted_unit = UNIT_MAP.get(unit, unit)
+
+        self._hass_unit = converted_unit
+        self._unit_of_measurement = converted_unit
 
     @staticmethod
     def match_type(type):
@@ -870,24 +863,23 @@ class TemperatureOperation(BasicNumericOperation):
             try:
                 unit = self._unit_template.render(device_state=device_state)
                 if unit in UNIT_MAP:
-                    self._unit = UNIT_MAP[unit]
+                    self._device_unit = UNIT_MAP[unit]
             except:
-                _LOGGER.debug("%s Could not render unit template for '%s'. Using last known unit.", self.log_prefix, self.id)
-        # --- START OF MODIFICATION ---
-        # If there's no unit_template, but there is a static unit_of_measurement (from an attribute), use it.
-        elif self._unit_of_measurement:
-            self._unit = self._unit_of_measurement
-        # --- END OF MODIFICATION ---
+                _LOGGER.debug("%s Could not render unit template for '%s'. Using last known device unit.", self.log_prefix, self.id)
+        
         return await super().async_update_state(device_state_override, debug)
 
     def convert_dev_to_hass(self, dev_value):
-        """Convert device state value to the HASS representation (Celsius)."""
+        """Convert device state value to the HASS representation."""
         try:
-            # --- START OF FIX: Ensure value is always a float for HASS ---
+            # --- START OF FIX: Ensure value is a clean float for HASS ---
             # The device might send an int (e.g., 22), but HA expects a float (22.0)
             # for temperatures. This mismatch was causing the optimistic update to fail.
             # By ensuring it's a float, we align with HA's state machine.
-            return float(TemperatureConverter.convert(float(dev_value), self._unit, UnitOfTemperature.CELSIUS))
+            # CRITICAL: We also strictly round the result after any unit conversions (like F->C) 
+            # to prevent fractions like 20.55555 from appearing in the UI.
+            raw_converted = float(TemperatureConverter.convert(float(dev_value), self._device_unit, self._hass_unit))
+            return float(int(round(raw_converted)))
             # --- END OF FIX ---
         except (ValueError, TypeError):
             return None  # Return None if the value is invalid.
@@ -900,7 +892,7 @@ class TemperatureOperation(BasicNumericOperation):
             v = self._max
 
         converted_temp = TemperatureConverter.convert(
-            float(v), UnitOfTemperature.CELSIUS, self._unit
+            float(v), self._hass_unit, self._device_unit
         )
         # --- START OF FIX: Remove hardcoded multiplication ---
         # Any multiplication (e.g., by 10) should be handled by the connection_template in the YAML

--- a/custom_components/climate_ip/protocol_8888.py
+++ b/custom_components/climate_ip/protocol_8888.py
@@ -215,40 +215,38 @@ class Samsung8888Client:
                         else:
                             # Fallback: read until closed or timeout and try to assemble complete JSON
                             buffer = b""
-                            timeout_task = asyncio.create_task(asyncio.sleep(2.0))
-                            read_task = asyncio.create_task(reader.read(8192))
-                            try:
-                                while True:
-                                    done, pending = await asyncio.wait(
-                                        [timeout_task, read_task],
-                                        return_when=asyncio.FIRST_COMPLETED
-                                    )
-                                    if timeout_task in done:
-                                        # Timeout - give up reading more
-                                        for task in pending:
-                                            task.cancel()
-                                        break
-                                    if read_task in done:
-                                        chunk = read_task.result()
-                                        if not chunk:
-                                            # Connection closed or no more data
-                                            break
-                                        buffer += chunk
-                                        # try parse as JSON; if fails, keep reading
-                                        try:
-                                            resp_body_candidate = buffer.decode('utf-8', 'ignore')
-                                            json.loads(resp_body_candidate)
-                                            resp_body = resp_body_candidate
-                                            break
-                                        except (json.JSONDecodeError, UnicodeDecodeError):
-                                            # Not complete yet, keep reading
-                                            read_task = asyncio.create_task(reader.read(8192))
-                                            continue
-                            finally:
-                                # Cancel any pending tasks
-                                for t in (timeout_task, read_task):
-                                    if not t.done():
-                                        t.cancel()
+                            end_time = asyncio.get_running_loop().time() + 5.0
+                            
+                            while True:
+                                timeout_left = end_time - asyncio.get_running_loop().time()
+                                if timeout_left <= 0:
+                                    _LOGGER.debug("%s [RAW] Read loop reached 5.0s absolute timeout.", self.log_prefix)
+                                    break
+                                
+                                try:
+                                    chunk = await asyncio.wait_for(reader.read(8192), timeout=timeout_left)
+                                    if not chunk:
+                                        break # Connection closed
+                                    
+                                    buffer += chunk
+                                    resp_body_candidate = buffer.decode('utf-8', 'ignore')
+                                    
+                                    if not resp_body_candidate.strip():
+                                        continue
+                                        
+                                    try:
+                                        json.loads(resp_body_candidate)
+                                        resp_body = resp_body_candidate
+                                        break # Valid JSON found
+                                    except json.JSONDecodeError:
+                                        continue # Not full JSON yet, keep reading
+                                        
+                                except asyncio.TimeoutError:
+                                    _LOGGER.debug("%s [RAW] Socket chunk read timed out.", self.log_prefix)
+                                    break
+                            
+                            if not resp_body:
+                                resp_body = buffer.decode('utf-8', 'ignore')
     
                         _LOGGER.debug("%s Headers received: %s", self.log_prefix, headers_received)
                         _LOGGER.debug("%s Content-Length: %d, Content-Type: %s", self.log_prefix, content_length, content_type)

--- a/custom_components/climate_ip/samsung_2878.py
+++ b/custom_components/climate_ip/samsung_2878.py
@@ -232,7 +232,7 @@ class ConnectionSamsung2878(Connection):
         async with self._close_lock:
             # Check if already closed to avoid redundant work and logs
             if self._writer is None and self._read_task is None:
-                _LOGGER.debug("%s Connection already closed, skipping.", self.log_prefix)
+
                 return
 
             self._is_ready.clear()
@@ -315,7 +315,7 @@ class ConnectionSamsung2878(Connection):
 
         # If we have a last known good configuration, prioritize it
         if self._last_successful_config:
-            _LOGGER.debug("%s Prioritizing last successful config: %s", self.log_prefix, self._last_successful_config)
+
             
             preferred_cert = self._last_successful_config.get('cert')
             preferred_cipher = self._last_successful_config.get('cipher_name')
@@ -342,7 +342,7 @@ class ConnectionSamsung2878(Connection):
             
             # Reconstruct the list with matching attempts first
             if matching_attempts:
-                _LOGGER.info("%s Optimizing reconnection: Restricting attempts to last known good configuration.", self.log_prefix)
+
                 all_attempts = matching_attempts
                 # We discard 'other_attempts' to avoid trying invalid configs (like No Cert)
 
@@ -356,20 +356,20 @@ class ConnectionSamsung2878(Connection):
             strategy_name = attempt['strategy_name']
 
             try:
-                _LOGGER.debug("%s Attempting connection with Strategy: '%s', Cipher: '%s', Verify: %s", self.log_prefix, strategy_name, cipher_name, verify_mode)
+
                 
                 # --- SSL Context Caching Logic ---
                 cache_key = (cert_path, ciphers, verify_mode) # The key must include all SSL parameters
                 ssl_context = self._ssl_context_cache.get(cache_key)
 
                 if not ssl_context:
-                    _LOGGER.debug("%s Creating and caching new SSL context for key: %s", self.log_prefix, cache_key)
+
                     ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
                     ssl_context.set_ciphers(ciphers)
                     ssl_context.verify_mode = verify_mode
                     ssl_context.check_hostname = False
                     if cert_path:
-                        _LOGGER.debug("%s Loading certificate: %s", self.log_prefix, os.path.basename(cert_path))
+
                         await asyncio.to_thread(ssl_context.load_verify_locations, cafile=cert_path)
                         await asyncio.to_thread(ssl_context.load_cert_chain, cert_path)
                     self._ssl_context_cache[cache_key] = ssl_context
@@ -424,7 +424,7 @@ class ConnectionSamsung2878(Connection):
             except (ConnectionRefusedError, asyncio.TimeoutError, OSError, ssl.SSLError) as e:
                 # This is an expected failure when the device is offline or the port is wrong.
                 # Log at debug level to avoid spamming logs when the device is intentionally off.
-                _LOGGER.debug("%s Connection attempt with '%s' / '%s' failed: %s. Trying next.", self.log_prefix, strategy_name, cipher_name, e)
+
                 last_error = e
                 await self._close_connection()
                 continue

--- a/custom_components/climate_ip/samsung_2878.yaml
+++ b/custom_components/climate_ip/samsung_2878.yaml
@@ -21,6 +21,14 @@ device:
       status_template: '{{ device_state.AC_ADD_SPI }}'
       connection_template: '<Request Type="DeviceControl"><Control CommandID="AC_ADD_SPI" DUID="{{duid}}"><Attr ID="AC_ADD_SPI" Value="{{value}}" /></Control></Request>'
       validation_template: '{% if "AC_ADD_SPI" in device_state %}valid{% endif %}'
+    beep:
+      type: switch
+      values:
+        'off': { value: 'Off' }
+        'on': { value: 'On' }
+      status_template: '{{ device_state.AC_ADD_BEEP }}'
+      connection_template: '<Request Type="DeviceControl"><Control CommandID="AC_ADD_BEEP" DUID="{{duid}}"><Attr ID="AC_ADD_SPI" Value="{{value}}" /></Control></Request>'
+      validation_template: '{% if "AC_ADD_BEEP" in device_state %}valid{% endif %}'
     auto_clean:
       type: switch
       values:

--- a/custom_components/climate_ip/samsungrac.yaml
+++ b/custom_components/climate_ip/samsungrac.yaml
@@ -27,6 +27,7 @@ device:
         'off': { value: 'Spi_Off', connection: { params: { json: { "options": [ "Spi_Off"] } } } }
         'on': { value: 'Spi_On', connection: { params: { json: { "options": [ "Spi_On"] } } } }
       status_template: '{{ "on" if "Spi_On" in device_state.Mode.options else "off" }}'
+      validation_template: '{{ "valid" if "Spi_On" in device_state.Mode.options or "Spi_Off" in device_state.Mode.options else "invalid" }}'
     auto_clean:
       type: switch
       connection:
@@ -35,6 +36,7 @@ device:
         'off': { value: 'Autoclean_Off', connection: { params: { json: { "options": [ "Autoclean_Off"] } } } }
         'on': { value: 'Autoclean_On', connection: { params: { json: { "options": [ "Autoclean_On"] } } } }
       status_template: '{{ "on" if "Autoclean_On" in device_state.Mode.options else "off" }}'
+      validation_template: '{{ "valid" if "Autoclean_On" in device_state.Mode.options or "Autoclean_Off" in device_state.Mode.options else "invalid" }}'
     beep:
       type: switch
       connection:
@@ -43,6 +45,7 @@ device:
         'off': { value: 'Volume_Mute', connection: { params: { json: { "options": [ "Volume_Mute"] } } } }
         'on': { value: 'Volume_100', connection: { params: { json: { "options": [ "Volume_100"] } } } }
       status_template: '{{ "off" if "Volume_Mute" in device_state.Mode.options else "on" }}'
+      validation_template: '{{ "valid" if "Volume_Mute" in device_state.Mode.options or "Volume_100" in device_state.Mode.options else "invalid" }}'
   operations:
     hvac: # hvac_mode
       type: modes
@@ -166,7 +169,7 @@ device:
     current_temperature:
       type: number
       status_template: '{{ device_state.Temperatures.0.current }}'
-      unit_template: 'Fahrenheit'
+      unit_template: 'Celsius'
     min_temp:
       type: number
       status_template: '8'

--- a/custom_components/climate_ip/sensor.py
+++ b/custom_components/climate_ip/sensor.py
@@ -138,7 +138,6 @@ class ClimateIpSensor(CoordinatorEntity[SamsungClimateCoordinator], SensorEntity
         All conversion logic is now handled by the property's status_template.
         """
         value = self.coordinator.get_property(self._key)
-        _LOGGER.debug("%s Sensor '%s' received value from coordinator: %s (type: %s)", self.log_prefix, self._key, value, type(value).__name__)
 
         if value is None or value == STATE_UNKNOWN:
             self._attr_native_value = None

--- a/custom_components/climate_ip/switch.py
+++ b/custom_components/climate_ip/switch.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
             
         for op in ops:
             if isinstance(op, str):
-                 _LOGGER.debug("Switch setup: 'op' is string '%s', fetching object.", op)
+
                  # Try to get the object from the controller
                  # We need to access the private _operations dict or use a getter if available
                  # operations property *should* return objects, but let's be safe.
@@ -51,7 +51,7 @@ async def async_setup_entry(
                      _LOGGER.error("Switch setup: Could not find operation object for '%s'", op)
                      continue
 
-            _LOGGER.debug("Switch setup: op type=%s, value=%s", type(op), op)
+
             # We skip 'power' because it's the main control for the climate entity
             if not hasattr(op, "id"):
                  _LOGGER.error("Switch setup: op has no id! op=%s", op)
@@ -61,7 +61,14 @@ async def async_setup_entry(
                 continue
                 
             if op.match_type(PROPERTY_TYPE_SWITCH):
-                _LOGGER.debug("Creating switch entity for %s", op.id)
+                # Check if the switch is valid for this device (based on capabilities)
+                # We use the raw device state from the controller for validation, not the wrapper
+                raw_device_state = controller.device_state
+                if not op.is_valid(raw_device_state):
+
+                    continue
+
+
                 entities.append(SamsungClimateSwitch(coordinator, op))
 
     if entities:

--- a/custom_components/climate_ip/translations/en.json
+++ b/custom_components/climate_ip/translations/en.json
@@ -11,7 +11,7 @@
     },
     "connection_method": {
       "options": {
-        "requests": "Legacy (requests)",
+        "requests": "Legacy (Obsolete)",
         "aiohttp": "Modern (aiohttp)"
       }
     }
@@ -22,7 +22,9 @@
         "title": "Adjust Options",
         "description": "Modify the integration options.",
         "data": {
-          "poll_interval": "Poll Interval (seconds)"
+          "poll_interval": "Poll Interval (seconds or hh:mm:ss)",
+          "temp_native_current": "Native Current Temp Unit (AC -> HA)",
+          "temp_native_target": "Native Target Temp Unit (HA -> AC)"
         }
       }
     }
@@ -46,7 +48,9 @@
           "name": "Name (Optional)",
           "token": "Token (Optional)",
           "cert": "Certificate (Optional)",
-          "poll_interval": "Poll Interval (seconds)"
+          "poll_interval": "Poll Interval (seconds)",
+          "temp_native_current": "Native Current Temp Unit (AC -> HA)",
+          "temp_native_target": "Native Target Temp Unit (HA -> AC)"
         }
       },
       "samsung_8888": {
@@ -101,7 +105,8 @@
       "timeout_8888": "Timeout expired. Make sure to press the 'AP' button on the device within the next 60 seconds.",
       "invalid_response": "The device returned an unexpected response. Pairing has failed.",
       "final_validation_failed": "Final validation failed. Could not connect to the device with the obtained credentials. Please restart the device and try again.",
-      "cert_not_found": "The certificate file was not found. Make sure the name is correct and it is in the integration's directory."
+      "cert_not_found": "The certificate file was not found. Make sure the name is correct and it is in the integration's directory.",
+      "invalid_poll_interval": "Invalid polling interval. Enter a number (seconds) or format 'hh:mm:ss'. Must be between 5s and 6h."
     },
     "abort": {
       "already_configured": "This device (same MAC address or ID) has already been configured.",

--- a/custom_components/climate_ip/translations/es.json
+++ b/custom_components/climate_ip/translations/es.json
@@ -11,7 +11,7 @@
     },
     "connection_method": {
       "options": {
-        "requests": "Legacy (requests)",
+        "requests": "Legacy (Obsoleto)",
         "aiohttp": "Moderno (aiohttp)"
       }
     }
@@ -22,7 +22,9 @@
         "title": "Ajustar Opciones",
         "description": "Modifica las opciones de la integración.",
         "data": {
-          "poll_interval": "Intervalo de sondeo (segundos)"
+          "poll_interval": "Intervalo de sondeo (segundos o hh:mm:ss)",
+          "temp_native_current": "Unidad Nativa Actual (AC -> HA)",
+          "temp_native_target": "Unidad Nativa Objetivo (HA -> AC)"
         }
       }
     }
@@ -46,7 +48,9 @@
           "name": "Nombre (Opcional)",
           "token": "Token (Opcional)",
           "cert": "Certificado (Opcional)",
-          "poll_interval": "Intervalo de sondeo (segundos)"
+          "poll_interval": "Intervalo de sondeo (segundos)",
+          "temp_native_current": "Unidad Nativa Actual (AC -> HA)",
+          "temp_native_target": "Unidad Nativa Objetivo (HA -> AC)"
         }
       },
       "samsung_8888": {
@@ -101,7 +105,8 @@
       "timeout_8888": "Tiempo de espera agotado. Asegúrate de presionar el botón 'AP' en el dispositivo en los próximos 60 segundos.",
       "invalid_response": "El dispositivo devolvió una respuesta inesperada. El emparejamiento ha fallado.",
       "final_validation_failed": "La validación final falló. No se pudo conectar al dispositivo con las credenciales obtenidas. Por favor, reinicia el dispositivo e inténtalo de nuevo.",
-      "cert_not_found": "El archivo de certificado no se encontró. Asegúrate de que el nombre es correcto y está en el directorio de la integración."
+      "cert_not_found": "El archivo de certificado no se encontró. Asegúrate de que el nombre es correcto y está en el directorio de la integración.",
+      "invalid_poll_interval": "Intervalo de sondeo inválido. Introduce un número (segundos) o formato 'hh:mm:ss'. Debe estar entre 5s y 6h."
     },
     "abort": {
       "already_configured": "Este dispositivo (misma dirección MAC o ID) ya ha sido configurado.",


### PR DESCRIPTION
## What's new in 9.0.12

### ✨ Added
- **Independent Native Temperature Units**: Two new options in the integration's Options Flow — *Native Current Temperature Unit* and *Native Target Temperature Unit*. Useful for devices that report temperatures internally in Fahrenheit while Home Assistant is configured in Celsius (or vice versa). Each unit can be configured independently.

### 🐛 Fixed
- **Connection Stability** ([protocol_8888.py](cci:7://file:///h:/custom_components/climate_ip/protocol_8888.py:0:0-0:0)): Fixed a critical bug where a missing `Content-Length` header from the AC caused the raw socket read loop to hang indefinitely, triggering 30-second timeouts in Home Assistant. The loop now uses an absolute 5-second deadline via `asyncio.wait_for`.
- **Temperature Display** ([climate.py](cci:7://file:///h:/custom_components/climate_ip/climate.py:0:0-0:0), [properties.py](cci:7://file:///h:/custom_components/climate_ip/properties.py:0:0-0:0)): Fixed fractional temperatures (e.g. `20.56°C`) appearing in the thermostat card. Temperatures are now explicitly rounded to whole numbers and the entity correctly reports [temperature_unit](cci:1://file:///h:/custom_components/climate_ip/climate.py:463:4-470:54) as the Home Assistant global display unit to prevent secondary frontend conversions.
- **Switch Validation** ([controller_yaml.py](cci:7://file:///h:/custom_components/climate_ip/controller_yaml.py:0:0-0:0), [samsung_2878.yaml](cci:7://file:///h:/custom_components/climate_ip/samsung_2878.yaml:0:0-0:0), [samsungrac.yaml](cci:7://file:///h:/custom_components/climate_ip/samsungrac.yaml:0:0-0:0)): Fixed a bug where [device_state](cci:1://file:///h:/custom_components/climate_ip/controller_yaml.py:1225:4-1240:17) passed to [validation_template](cci:1://file:///h:/custom_components/climate_ip/properties.py:190:4-192:40) was incorrectly typed as a `ClimateIPDeviceState` object instead of a raw dictionary, causing `purify`, `auto_clean` and other switches to always fail validation and not appear in Home Assistant.
- **Log Noise**: Removed verbose `DEBUG` log statements across `switch.py`, `sensor.py`, [samsung_2878.py](cci:7://file:///h:/custom_components/climate_ip/samsung_2878.py:0:0-0:0), [controller_yaml.py](cci:7://file:///h:/custom_components/climate_ip/controller_yaml.py:0:0-0:0) and [properties.py](cci:7://file:///h:/custom_components/climate_ip/properties.py:0:0-0:0). Logs are now much cleaner during normal operation.

### 📄 Files changed
[climate.py](cci:7://file:///h:/custom_components/climate_ip/climate.py:0:0-0:0) · [config_flow.py](cci:7://file:///h:/custom_components/climate_ip/config_flow.py:0:0-0:0) · [connection_aiohttp.py](cci:7://file:///h:/custom_components/climate_ip/connection_aiohttp.py:0:0-0:0) · [const.py](cci:7://file:///h:/custom_components/climate_ip/const.py:0:0-0:0) · [controller_yaml.py](cci:7://file:///h:/custom_components/climate_ip/controller_yaml.py:0:0-0:0) · `manifest.json` · [properties.py](cci:7://file:///h:/custom_components/climate_ip/properties.py:0:0-0:0) · [protocol_8888.py](cci:7://file:///h:/custom_components/climate_ip/protocol_8888.py:0:0-0:0) · [samsung_2878.py](cci:7://file:///h:/custom_components/climate_ip/samsung_2878.py:0:0-0:0) · [samsung_2878.yaml](cci:7://file:///h:/custom_components/climate_ip/samsung_2878.yaml:0:0-0:0) · [samsungrac.yaml](cci:7://file:///h:/custom_components/climate_ip/samsungrac.yaml:0:0-0:0) · `sensor.py` · `switch.py` · [CHANGELOG.md](cci:7://file:///h:/custom_components/climate_ip/CHANGELOG.md:0:0-0:0)
