### PR TITLE
v9.1.0: Fix critical TLS 1.3 hang on Samsung AC devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## [9.0.12] - Unreleased
+## [9.1.0] - 2026-02-24
+
+### Added
+- **TLS Visibility Logs**: Added `DEBUG`-level logs in all 5 connection engines (`samsung_2878.py`, `protocol_8888.py`, `connection_aiohttp.py`, `connection_request.py`, `token_acquirer.py`) that print the configured `Min`/`Max` TLS version at context creation time, and the negotiated TLS version after a successful handshake. Helps diagnose future SSL compatibility issues without a packet capture.
+
+### Fixed
+- **Critical TLS Hang (AC Port 8888/2878)**: Samsung AC firmware hangs indefinitely when receiving a TLS 1.3 Client Hello. On modern Home Assistant OS (Python 3.10+, OpenSSL 3.x), `ssl.PROTOCOL_TLSv1` no longer guarantees a TLS 1.0-only Client Hello and may negotiate TLS 1.3 by default, triggering the firmware bug. Fixed by migrating all SSL context creation to `PROTOCOL_TLS_CLIENT` with an explicit `maximum_version = ssl.TLSVersion.TLSv1_2` cap. This prevents the TLS 1.3 Client Hello while allowing the AC to negotiate down to the version it supports (TLS 1.0 or 1.1).
+- **ValueError on SSL Context Creation**: Using `ssl.PROTOCOL_TLS_CLIENT` requires `check_hostname = False` to be set **before** `verify_mode = CERT_NONE`, otherwise Python raises `ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled`. Fixed the assignment order across all 5 connection engines (`samsung_2878.py`, `protocol_8888.py`, `connection_aiohttp.py`, `connection_request.py`, `token_acquirer.py`, `token_acquirer_8888.py`).
+- **Log Noise**: The `SSLContext configured...` debug log was being printed once per cipher strategy attempt (up to 5 times in `samsung_2878.py`). Fixed with a `logged_ssl_config` guard so it only prints once per connection cycle.
+
+## [9.0.12] - 2026-02-23
 
 ### Added
 - **Independent Native Temperature Units**: Added two separate configuration options (`Native Current Temperature Unit` and `Native Target Temperature Unit`) accessible from the integration's Options Flow. This allows devices that report temperatures in Fahrenheit to be correctly converted and displayed in the Home Assistant global unit (Celsius or Fahrenheit), independently for current and target temperatures. New constants `CONF_TEMP_NATIVE_CURRENT` and `CONF_TEMP_NATIVE_TARGET` added to `const.py`.

--- a/custom_components/climate_ip/connection_aiohttp.py
+++ b/custom_components/climate_ip/connection_aiohttp.py
@@ -128,8 +128,10 @@ class ConnectionAiohttp8888(Connection):
         try:
             _LOGGER.debug("%s [aiohttp] Creating custom SSL context. Cert: %s, Insecure: %s", self.log_prefix, has_cert, insecure_ssl)
             
-            # Use PROTOCOL_TLSv1 for maximum compatibility (as in requests)
-            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            # Use PROTOCOL_TLS_CLIENT to negotiate, but cap at TLS 1.2
+            # because Samsung ACs hang when receiving a TLS 1.3 Client Hello.
+            protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
+            context = ssl.SSLContext(protocol)
             
             # If insecure_ssl or mTLS (self-signed), we don't verify hostname/chain
             context.check_hostname = False
@@ -138,11 +140,29 @@ class ConnectionAiohttp8888(Connection):
             # Replicate the 'requests' logic to allow ALL ciphers (fixes Handshake Failure)
             context.set_ciphers("ALL:@SECLEVEL=0")
             
+            # Cap the maximum version to TLS 1.2 to prevent the AC from hanging
+            if hasattr(ssl, 'TLSVersion'):
+                if hasattr(ssl.TLSVersion, 'TLSv1_2'):
+                    try:
+                        context.maximum_version = ssl.TLSVersion.TLSv1_2
+                    except Exception as e:
+                        _LOGGER.debug("%s [aiohttp] Could not set TLS max version: %s", self.log_prefix, e)
+                if hasattr(ssl.TLSVersion, 'TLSv1'):
+                    try:
+                        context.minimum_version = ssl.TLSVersion.TLSv1
+                    except Exception:
+                        pass
+            
             if has_cert:
                 _LOGGER.debug("%s [aiohttp] Loading mTLS cert from: %s", self.log_prefix, self._cert_path)
                 loop = asyncio.get_running_loop()
                 load_chain_func = partial(context.load_cert_chain, self._cert_path)
                 await loop.run_in_executor(None, load_chain_func)
+
+            # Log the configured TLS limits
+            max_ver = getattr(context, 'maximum_version', 'Unknown')
+            min_ver = getattr(context, 'minimum_version', 'Unknown')
+            _LOGGER.debug("%s [aiohttp] SSLContext configured. Min: %s, Max: %s", self.log_prefix, str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
             
             return context
         except Exception as e:
@@ -322,7 +342,15 @@ class ConnectionAiohttp8888(Connection):
                     # Update timeout to be more granular
                     async with self._session.request("GET", probe_url, headers=probe_headers, ssl=self._shared_state["ssl_context"], timeout=aiohttp.ClientTimeout(total=10, sock_read=5)) as response:
                         if response.status in (200, 401, 403, 405): # Added 405 for Method Not Allowed (probing POST with GET)
-                            _LOGGER.info("%s [aiohttp] Connection successful and memorized. Status: %s", self.log_prefix, response.status)
+                            # Attempt to log the negotiated TLS version
+                            try:
+                                transport = response.connection.transport if response.connection else None
+                                ssl_obj = transport.get_extra_info('ssl_object') if transport else None
+                                negotiated_tls = ssl_obj.version() if ssl_obj else "Unknown"
+                                _LOGGER.info("%s [aiohttp] Connection successful. Status: %s. Negotiated TLS: %s", self.log_prefix, response.status, negotiated_tls)
+                            except Exception:
+                                _LOGGER.info("%s [aiohttp] Connection successful and memorized. Status: %s", self.log_prefix, response.status)
+                                
                             self._shared_state["initialized"] = True
                             
                             # --- START OF FIX: Optimization - Return text for reuse ---

--- a/custom_components/climate_ip/connection_request.py
+++ b/custom_components/climate_ip/connection_request.py
@@ -59,9 +59,30 @@ class SamsungHTTPAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
+        ssl_context = ssl.SSLContext(protocol)
         ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
         ssl_context.set_ciphers("ALL:@SECLEVEL=0")
+        
+        # Cap the maximum version to TLS 1.2 to prevent the AC from hanging
+        if hasattr(ssl, 'TLSVersion'):
+            if hasattr(ssl.TLSVersion, 'TLSv1_2'):
+                try:
+                    ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
+                except Exception as e:
+                    _LOGGER.debug("[SamsungHTTPAdapter] Could not set TLS max version: %s", e)
+            if hasattr(ssl.TLSVersion, 'TLSv1'):
+                try:
+                    ssl_context.minimum_version = ssl.TLSVersion.TLSv1
+                except Exception:
+                    pass
+
+        # Log the configured TLS limits
+        max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
+        min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
+        _LOGGER.debug("[SamsungHTTPAdapter] SSLContext configured. Min: %s, Max: %s", str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
+
         pool_kwargs["ssl_context"] = ssl_context
         
         # --- START OF FIX: Limit Pool Concurrency ---
@@ -113,6 +134,7 @@ class ConnectionRequestBase(Connection):
         self.update_configuration_from_hass(hass_config)
         self._condition_template = None
         self._thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        self._is_closing = False
 
         # --- START OF FIX: Persistent Session ---
         # Initialize a persistent session to support Keep-Alive.
@@ -176,6 +198,7 @@ class ConnectionRequestBase(Connection):
     def _close_sync(self):
         """Explicitly close the session and thread pool (Synchronous)."""
         _LOGGER.debug("%s [ConnectionRequest] _close_sync: Cleanup started.", self.log_prefix)
+        self._is_closing = True
         
         if hasattr(self, "_session") and self._session:
             try:
@@ -322,6 +345,10 @@ class ConnectionRequestBase(Connection):
                 # We do NOT remount it here to safe-guard connection reuse.
 
                 for attempt in range(REQUEST_MAX_RETRIES):
+                    if self._is_closing:
+                        _LOGGER.debug("%s [ConnectionRequest] Connection is closing, aborting request.", self.log_prefix)
+                        raise ConnectionError("Connection is closing")
+                        
                     try:
                         _LOGGER.debug("%s Request (attempt %s/%s): %s", self.log_prefix, attempt + 1, REQUEST_MAX_RETRIES, mask_sensitive_data(params))
                         
@@ -361,6 +388,16 @@ class ConnectionRequestBase(Connection):
                         
                         resp = session.request(**request_params)
                         
+                        # Attempt to log the negotiated TLS version
+                        try:
+                            # Access the underlying urllib3 connection's socket
+                            raw_conn = getattr(resp.raw, '_connection', None)
+                            sock = getattr(raw_conn, 'sock', None) if raw_conn else None
+                            negotiated_tls = sock.version() if sock and hasattr(sock, 'version') else "Unknown"
+                            _LOGGER.debug("%s [ConnectionRequest] Request successful. Negotiated TLS: %s", self.log_prefix, negotiated_tls)
+                        except Exception:
+                            pass
+                            
                         # --- START OF FIX: HTTP Version Detection ---
                         # Dynamically adjust Keep-Alive support based on server response.
                         # resp.raw.version is an integer: 10 (HTTP/1.0) or 11 (HTTP/1.1)
@@ -419,8 +456,9 @@ class ConnectionRequestBase(Connection):
                         if e.response.status_code in (401, 403):
                             _LOGGER.error("%s Authentication error: %s. Not retrying", self.log_prefix, e)
                             raise AuthError(f"Authentication failed with status {e.response.status_code}") from e
-                        # Retrying 500 errors with longer delay
                         elif 500 <= e.response.status_code < 600 and attempt < REQUEST_MAX_RETRIES - 1:
+                            if self._is_closing:
+                                raise ConnectionError("Connection is closing")
                             _LOGGER.warning("%s Server error (%s). Retrying in %s seconds", self.log_prefix, e.response.status_code, LOCAL_RETRY_DELAY)
                             time.sleep(LOCAL_RETRY_DELAY)
                             continue
@@ -445,6 +483,8 @@ class ConnectionRequestBase(Connection):
                          
                         # If we were already in force close mode OR ran out of retries
                         if attempt < REQUEST_MAX_RETRIES - 1:
+                            if self._is_closing:
+                                raise ConnectionError("Connection is closing")
                             _LOGGER.warning("%s ReadTimeout error. Retrying in %s seconds", self.log_prefix, LOCAL_RETRY_DELAY)
                             time.sleep(LOCAL_RETRY_DELAY)
                             continue
@@ -454,6 +494,8 @@ class ConnectionRequestBase(Connection):
 
                     except requests.exceptions.Timeout as e:
                         if attempt < REQUEST_MAX_RETRIES - 1:
+                            if self._is_closing:
+                                raise ConnectionError("Connection is closing")
                             _LOGGER.warning("%s Request timed out. Retrying in %s seconds", self.log_prefix, LOCAL_RETRY_DELAY)
                             time.sleep(LOCAL_RETRY_DELAY)
                             continue
@@ -475,6 +517,8 @@ class ConnectionRequestBase(Connection):
                                 continue
 
                         if attempt < REQUEST_MAX_RETRIES - 1:
+                            if self._is_closing:
+                                raise ConnectionError("Connection is closing")
                             _LOGGER.warning("%s Connection error. Retrying in %s seconds", self.log_prefix, LOCAL_RETRY_DELAY)
                             time.sleep(LOCAL_RETRY_DELAY)
                             continue

--- a/custom_components/climate_ip/manifest.json
+++ b/custom_components/climate_ip/manifest.json
@@ -13,5 +13,5 @@
     "requests>=2.21.0",
     "xmltodict>=0.13.0"
   ],
-  "version": "9.0.12"
+  "version": "9.1.0"
 }

--- a/custom_components/climate_ip/protocol_8888.py
+++ b/custom_components/climate_ip/protocol_8888.py
@@ -45,13 +45,28 @@ class Samsung8888Client:
 
     async def _create_ssl_context(self) -> ssl.SSLContext:
         """Configure SSL, replicating the logic from connection_request.py."""
-        # Always use Legacy mode (TLSv1) as it is the most compatible
-        ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        # Use PROTOCOL_TLS_CLIENT to negotiate, but cap at TLS 1.2
+        # because Samsung ACs hang when receiving a TLS 1.3 Client Hello.
+        protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
+        ctx = ssl.SSLContext(protocol)
         
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         # Use ALL:@SECLEVEL=0 as in the original code for maximum compatibility
         ctx.set_ciphers("ALL:@SECLEVEL=0")
+        
+        # Cap the maximum version to TLS 1.2 to prevent the AC from hanging
+        if hasattr(ssl, 'TLSVersion'):
+            if hasattr(ssl.TLSVersion, 'TLSv1_2'):
+                try:
+                    ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+                except Exception as e:
+                    _LOGGER.debug("%s [protocol_8888] Could not set TLS max version: %s", self.log_prefix, e)
+            if hasattr(ssl.TLSVersion, 'TLSv1'):
+                try:
+                    ctx.minimum_version = ssl.TLSVersion.TLSv1
+                except Exception:
+                    pass
         
         # --- START OF FIX: Optimize SSL for low-memory devices ---
         # Disable session tickets and compression to reduce handshake overhead
@@ -89,6 +104,11 @@ class Samsung8888Client:
                     e,
                 )
         
+        # Log the configured TLS limits
+        max_ver = getattr(ctx, 'maximum_version', 'Unknown')
+        min_ver = getattr(ctx, 'minimum_version', 'Unknown')
+        _LOGGER.debug("%s [protocol_8888] SSLContext configured. Min: %s, Max: %s", self.log_prefix, str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
+
         return ctx
 
     async def connect(self):
@@ -97,9 +117,19 @@ class Samsung8888Client:
         if not self._ssl_context:
             self._ssl_context = await self._create_ssl_context()
         try:
-            self._reader, self._writer = await asyncio.open_connection(
-                self.host, self.port, ssl=self._ssl_context
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port, ssl=self._ssl_context),
+                timeout=10.0
             )
+            # Attempt to log the negotiated TLS version
+            try:
+                ssl_obj = self._writer.get_extra_info('ssl_object')
+                negotiated_tls = ssl_obj.version() if ssl_obj else "Unknown"
+                _LOGGER.debug("%s [Samsung8888Client] Connected successfully. Negotiated TLS: %s", self.log_prefix, negotiated_tls)
+            except Exception:
+                pass
+        except asyncio.TimeoutError:
+            raise ConnectionError(f"Connection timed out to {self.host}:{self.port}")
         except Exception as e:
             raise ConnectionError(f"Connection error: {e}")
 
@@ -169,9 +199,12 @@ class Samsung8888Client:
                         
                         request_str = "\r\n".join(req) + "\r\n\r\n" + (payload if payload else "")
                         writer.write(request_str.encode('utf-8'))
-                        await writer.drain()
-                        
-                        status_line = await reader.readline()
+                        try:
+                            await asyncio.wait_for(writer.drain(), timeout=5.0)
+                            
+                            status_line = await asyncio.wait_for(reader.readline(), timeout=10.0)
+                        except asyncio.TimeoutError:
+                            raise ConnectionError("Timeout sending request or reading status line")
                         if not status_line:
                             raise ConnectionResetError("Remote closure")
                         
@@ -185,7 +218,11 @@ class Samsung8888Client:
                         content_length = 0
                         content_type = ""
                         while True:
-                            line = await reader.readline()
+                            try:
+                                line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+                            except asyncio.TimeoutError:
+                                raise ConnectionError("Timeout reading headers")
+                            
                             if not line or line == b'\r\n':
                                 break
                             line_str = line.decode('utf-8', 'ignore').strip()
@@ -206,7 +243,10 @@ class Samsung8888Client:
                         resp_body = ""
                         if content_length > 0:
                             try:
-                                resp_body = (await reader.readexactly(content_length)).decode('utf-8', 'ignore')
+                                chunk = await asyncio.wait_for(reader.readexactly(content_length), timeout=10.0)
+                                resp_body = chunk.decode('utf-8', 'ignore')
+                            except asyncio.TimeoutError:
+                                raise ConnectionError("Timeout reading response body")
                             except Exception:
                                 resp_body = ""
                         elif content_length == 0 and "content-length" in [h.lower().split(':')[0] for h in headers_received]:
@@ -278,6 +318,10 @@ class Samsung8888Client:
                         else:
                             raise ConnectionError("Unstable connection")
                     except AuthError:
+                        await self.close()
+                        raise
+                    except asyncio.CancelledError:
+                        _LOGGER.debug("%s [RAW] Request was cancelled by coordinator timeout. Closing socket.", self.log_prefix)
                         await self.close()
                         raise
                     except Exception as e:

--- a/custom_components/climate_ip/samsung_2878.py
+++ b/custom_components/climate_ip/samsung_2878.py
@@ -348,6 +348,7 @@ class ConnectionSamsung2878(Connection):
 
         connection_successful = False
         last_error = None
+        logged_ssl_config = False
 
         for attempt in all_attempts:
             cert_path = attempt['cert']
@@ -364,14 +365,35 @@ class ConnectionSamsung2878(Connection):
 
                 if not ssl_context:
 
-                    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+                    protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
+                    ssl_context = ssl.SSLContext(protocol)
                     ssl_context.set_ciphers(ciphers)
-                    ssl_context.verify_mode = verify_mode
                     ssl_context.check_hostname = False
+                    ssl_context.verify_mode = verify_mode
+                    
+                    if hasattr(ssl, 'TLSVersion'):
+                        if hasattr(ssl.TLSVersion, 'TLSv1_2'):
+                            try:
+                                ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
+                            except Exception as e:
+                                _LOGGER.debug("Could not set TLS max version: %s", e)
+                        if hasattr(ssl.TLSVersion, 'TLSv1'):
+                            try:
+                                ssl_context.minimum_version = ssl.TLSVersion.TLSv1
+                            except Exception:
+                                pass
+                                
                     if cert_path:
-
                         await asyncio.to_thread(ssl_context.load_verify_locations, cafile=cert_path)
                         await asyncio.to_thread(ssl_context.load_cert_chain, cert_path)
+
+                    # Log the configured TLS limits only once per connection cycle
+                    if not logged_ssl_config:
+                        max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
+                        min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
+                        _LOGGER.debug("%s [samsung_2878] SSLContext configured. Min: %s, Max: %s", self.log_prefix, str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
+                        logged_ssl_config = True
+
                     self._ssl_context_cache[cache_key] = ssl_context
 
                 # --- START OF FIX: Use raw socket with TCP KEEPALIVE ---
@@ -411,9 +433,10 @@ class ConnectionSamsung2878(Connection):
                 ssl_object = self._writer.get_extra_info('ssl_object')
                 if ssl_object:
                     cipher = ssl_object.cipher()
+                    negotiated_tls = ssl_object.version() or "Unknown"
                     _LOGGER.info(
-                        "%s SSL connection established. Protocol: %s, Cipher: %s, Verify: %s",
-                        self.log_prefix, cipher[1], cipher[0], verify_mode
+                        "%s SSL connection established. Protocol: %s, Cipher: %s, Verify: %s, Negotiated TLS: %s",
+                        self.log_prefix, cipher[1], cipher[0], verify_mode, negotiated_tls
                     )
 
                 # Memorize the successful configuration for future reconnections

--- a/custom_components/climate_ip/token_acquirer.py
+++ b/custom_components/climate_ip/token_acquirer.py
@@ -82,6 +82,8 @@ class SamsungTokenAcquirer:
             for cipher_config in cipher_configs
         ]
 
+        logged_ssl_config = False
+
         for attempt in all_attempts:
             cert_path = attempt['cert']
             ciphers, cipher_name = attempt['cipher_config']
@@ -90,10 +92,23 @@ class SamsungTokenAcquirer:
 
             try:
                 _LOGGER.debug("Attempting connection with Strategy: '%s', Cipher: '%s', Verify: %s", strategy_name, cipher_name, verify_mode)
-                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+                protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
+                ssl_context = ssl.SSLContext(protocol)
                 ssl_context.set_ciphers(ciphers)
-                ssl_context.verify_mode = verify_mode
                 ssl_context.check_hostname = False
+                ssl_context.verify_mode = verify_mode
+                
+                if hasattr(ssl, 'TLSVersion'):
+                    if hasattr(ssl.TLSVersion, 'TLSv1_2'):
+                        try:
+                            ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
+                        except Exception as e:
+                            _LOGGER.debug("Could not set TLS max version: %s", e)
+                    if hasattr(ssl.TLSVersion, 'TLSv1'):
+                        try:
+                            ssl_context.minimum_version = ssl.TLSVersion.TLSv1
+                        except Exception:
+                            pass
 
                 if cert_path:
                     _LOGGER.debug("Loading certificate: %s", os.path.basename(cert_path))
@@ -105,11 +120,26 @@ class SamsungTokenAcquirer:
                         _LOGGER.error("Failed to load certificate '%s': %s", cert_path, e)
                         raise CertNotFound(f"Failed to load certificate file: {e}") from e
 
+                # Log the configured TLS limits
+                if not logged_ssl_config:
+                    max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
+                    min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
+                    _LOGGER.debug("[SamsungTokenAcquirer] SSLContext configured. Min: %s, Max: %s", str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
+                    logged_ssl_config = True
+
                 conn_future = asyncio.open_connection(self._ip_address, 2878, ssl=ssl_context)
                 self._reader, self._writer = await asyncio.wait_for(conn_future, timeout=15)
                 
                 _LOGGER.info("SSL connection successful with Strategy: '%s', Cipher: '%s'", strategy_name, cipher_name)
                 
+                # Attempt to log the negotiated TLS version
+                try:
+                    ssl_obj = self._writer.get_extra_info('ssl_object')
+                    negotiated_tls = ssl_obj.version() if ssl_obj else "Unknown"
+                    _LOGGER.debug("[SamsungTokenAcquirer] Negotiated TLS Version: %s", negotiated_tls)
+                except Exception:
+                    pass
+
                 # Connection successful, read initial handshake and return the working cert path
                 try:
                     initial_data = await asyncio.wait_for(self._reader.read(4096), timeout=15.0)

--- a/custom_components/climate_ip/token_acquirer_8888.py
+++ b/custom_components/climate_ip/token_acquirer_8888.py
@@ -152,8 +152,19 @@ class SamsungTokenAcquirer8888:
         """Starts the custom TCP listener server."""
         try:
             # Setup SSL for the server
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-            ssl_context.minimum_version = ssl.TLSVersion.TLSv1
+            protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
+            ssl_context = ssl.SSLContext(protocol)
+            if hasattr(ssl, 'TLSVersion'):
+                if hasattr(ssl.TLSVersion, 'TLSv1'):
+                    try:
+                        ssl_context.minimum_version = ssl.TLSVersion.TLSv1
+                    except Exception:
+                        pass
+                if hasattr(ssl.TLSVersion, 'TLSv1_2'):
+                    try:
+                        ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
+                    except Exception as e:
+                        _LOGGER.debug("Could not set TLS max version: %s", e)
             try:
                 ssl_context.set_ciphers('HIGH:!aNULL:!MD5:@SECLEVEL=0')
             except Exception as e:
@@ -162,6 +173,11 @@ class SamsungTokenAcquirer8888:
             await self._hass.async_add_executor_job(
                 ssl_context.load_cert_chain, self._cert_path
             )
+            
+            # Log the configured TLS limits
+            max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
+            min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
+            _LOGGER.debug("[SamsungTokenAcquirer8888 Server] SSLContext configured. Min: %s, Max: %s", str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
             
             # Start the server
             self._server = await asyncio.start_server(
@@ -188,8 +204,19 @@ class SamsungTokenAcquirer8888:
         _LOGGER.info("Requesting token from AC at %s:%s", self._ac_ip, self._ac_port)
 
         # Setup Client SSL Context
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-        ssl_context.minimum_version = ssl.TLSVersion.TLSv1
+        protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
+        ssl_context = ssl.SSLContext(protocol)
+        if hasattr(ssl, 'TLSVersion'):
+            if hasattr(ssl.TLSVersion, 'TLSv1'):
+                try:
+                    ssl_context.minimum_version = ssl.TLSVersion.TLSv1
+                except Exception:
+                    pass
+            if hasattr(ssl.TLSVersion, 'TLSv1_2'):
+                try:
+                    ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
+                except Exception as e:
+                    _LOGGER.debug("Could not set TLS max version: %s", e)
         ssl_context.set_ciphers('HIGH:!aNULL:!MD5:@SECLEVEL=0')
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
@@ -197,6 +224,11 @@ class SamsungTokenAcquirer8888:
         await self._hass.async_add_executor_job(
             ssl_context.load_cert_chain, self._cert_path
         )
+
+        # Log the configured TLS limits
+        max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
+        min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
+        _LOGGER.debug("[SamsungTokenAcquirer8888 Client] SSLContext configured. Min: %s, Max: %s", str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
 
         try:
             async with aiohttp.ClientSession() as session:
@@ -220,6 +252,16 @@ class SamsungTokenAcquirer8888:
 
                     if response.status == 200:
                         _LOGGER.info("Token request accepted by AC (200 OK)")
+                        
+                        # Attempt to log the negotiated TLS version
+                        try:
+                            transport = response.connection.transport if response.connection else None
+                            ssl_obj = transport.get_extra_info('ssl_object') if transport else None
+                            negotiated_tls = ssl_obj.version() if ssl_obj else "Unknown"
+                            _LOGGER.debug("[SamsungTokenAcquirer8888 Client] Negotiated TLS Version: %s", negotiated_tls)
+                        except Exception:
+                            pass
+                            
                         # Try to read body for debugging, but don't fail if it times out (missing Content-Length)
                         try:
                             resp_text = await asyncio.wait_for(response.text(), timeout=2.0)


### PR DESCRIPTION
## What's New in v9.1.0

### 🐛 Critical Fix: TLS 1.3 Hang on Samsung AC (Port 8888 & 2878)

Samsung AC firmware hangs indefinitely when it receives a TLS 1.3 Client Hello. On modern Home Assistant OS (Python 3.10+, OpenSSL 3.x), the previously used `ssl.PROTOCOL_TLSv1` no longer guarantees a TLS 1.0-only handshake and may negotiate TLS 1.3 by default, silently triggering this firmware bug — causing all connections to time out after 10–30 seconds.

**Fix**: All SSL context creation now uses `PROTOCOL_TLS_CLIENT` with an explicit `maximum_version = ssl.TLSVersion.TLSv1_2` cap. This prevents the TLS 1.3 Client Hello while still allowing the AC to negotiate down to TLS 1.0/1.1 as needed.

### 🐛 Fix: ValueError on SSL Context Creation

`ssl.PROTOCOL_TLS_CLIENT` requires `check_hostname = False` to be set **before** `verify_mode = CERT_NONE`. The incorrect assignment order was raising a `ValueError` across all connection engines, preventing connections from being established.

### ✨ New: TLS Version Visibility Logs

All connection engines now log the configured Min/Max TLS version at connection time, and the actually negotiated TLS protocol after a successful handshake. Useful for diagnosing future SSL compatibility issues without a packet capture.

### Files Changed
- `connection_request.py`, `connection_aiohttp.py`, `protocol_8888.py`
- `samsung_2878.py`, `token_acquirer.py`, `token_acquirer_8888.py`