### PR TITLE
Release v9.1.1: Ping-Gate protection and HA Repair Issues for all AC devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [9.1.1] - 2026-02-26
+
+### Added
+- **Ping Gate (Port 2878)**: Implemented ICMP connectivity pre-check before every TCP reconnection attempt for port 2878 devices. If the device is unreachable at network level, the integration skips the TCP socket entirely to protect fragile AC firmware from hanging on connection attempts. Uses a fixed 10-second retry interval when the device is offline, and an adaptive exponential backoff (5→10→20→40→…s) once the ping succeeds but the port connection fails.
+- **Ping Gate (Port 8888)**: Extended the ICMP pre-check to port 8888 devices via the `DataUpdateCoordinator` polling cycle. If the device is unreachable, the polling cycle returns immediately without opening a TCP/SSL socket, reducing unnecessary network traffic and protecting older AC units.
+- **HA Repair Issues (All Devices)**: After 3 consecutive connection failures (via ping or socket), a Home Assistant Repair Issue (`connection_failed`) is automatically created in the frontend, identifying the device by name and IP. The issue is automatically resolved when the device reconnects successfully.
+- **Shared Ping Utility**: Extracted `async_check_network_reachability` to `helpers.py` as a shared async helper used by all connection engines. Supports Linux/macOS (`ping -c 1 -W 2`) and Windows (`ping -n 1 -w 2000`).
+
+### Changed
+- **Code Duplication**: Centralized the `check_execute_condition` logic into the base `Connection` class to resolve code duplication across `connection_request.py`, `connection_aiohttp.py`, and `connection_raw.py`.
+- **SSL Context**: Consolidated SSL context creation by moving `async_create_samsung_ssl_context` to `helpers.py`. All connection engines now use this shared helper, ensuring consistent TLS and cipher parameter sets.
+- **Log Refinement**: Removed redundant and noisy `[DEBUG_PRINT]`, `[DEBUG coordinator]`, and `Shared SSLContext configured` statements during application startup for a cleaner standard output.
+- **Log Verbosity (Offline Devices)**: Downgraded transient and persistent connection failure log messages in `coordinator.py` from `WARNING`/`ERROR` to `DEBUG` to prevent log spam when a device is intentionally offline or powered off.
+
+### Fixed
+- **Parameter Resolution**: Removed a fragile "template hack" in connection instantiation (`create_updated`) that forced static parameters into mock Jinja templates. Static parameters are now stored natively and resolved accurately via a new `_resolve_async_params` helper in `properties.py`.
+- **TLS Version Logging**: Fixed an issue where the `SSLContext configured...` logs printed raw OpenSSL integer codes (e.g., `769`, `771`) instead of readable names like `TLSv1` or `TLSv1_2` in certain Python environments.
+
 ## [9.1.0] - 2026-02-24
 
 ### Added

--- a/custom_components/climate_ip/__init__.py
+++ b/custom_components/climate_ip/__init__.py
@@ -114,8 +114,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         session = async_get_clientsession(hass)
     # --- END OF FIX ---
 
-    _LOGGER.debug("Starting setup for entry %s with runtime config: %s", entry.entry_id, mask_sensitive_data(runtime_config))
-
+    _LOGGER.info("Starting setup for device %s at %s (Device Type: %s)", 
+                 runtime_config.get(CONF_MAC, "Unknown"), 
+                 runtime_config.get("ip_address", "Unknown"), 
+                 device_type)
     if devices_config := runtime_config.get(CONF_DEVICES):
         coordinators = {}
         for device_info in devices_config:

--- a/custom_components/climate_ip/connection.py
+++ b/custom_components/climate_ip/connection.py
@@ -55,6 +55,38 @@ class Connection:
     
     # --- END OF MODIFICATION (Milestone 0) ---
     
+    def check_execute_condition(self, device_state) -> bool:
+        """Return True if the command should be executed for the given device state.
+
+        Evaluates the optional Jinja2 ``condition_template`` attribute.  The
+        template must render to the string ``"1"`` for the command to run.
+        Any other rendered value means skip; a missing template means always run.
+
+        This single shared implementation replaces 4 previously duplicated copies
+        in connection_request, connection_request_tls_auto, connection_aiohttp and
+        connection_raw.
+        """
+        _log = self._logger or logging.getLogger(__name__)
+        condition = getattr(self, "condition_template", None)
+        if condition is None:
+            return True
+        try:
+            rendered = condition.render(device_state=device_state)
+            _log.debug(
+                "%s Execute condition result: %s",
+                getattr(self, "log_prefix", ""),
+                rendered,
+            )
+            return str(rendered).strip() == "1"
+        except Exception as e:  # pylint: disable=broad-except
+            _log.error(
+                "%s Error evaluating execute condition, executing command anyway. Error: %s",
+                getattr(self, "log_prefix", ""),
+                e,
+                exc_info=True,
+            )
+            return True
+
     def execute_legacy(self, template, value, device_state, device_id):
         """execute connection and return JSON object as result or None if unsuccesful."""
         return None

--- a/custom_components/climate_ip/connection_aiohttp.py
+++ b/custom_components/climate_ip/connection_aiohttp.py
@@ -8,6 +8,7 @@ import copy
 import json
 import time
 import ssl
+import ssl
 from urllib.parse import urlparse
 import logging
 import os
@@ -128,41 +129,13 @@ class ConnectionAiohttp8888(Connection):
         try:
             _LOGGER.debug("%s [aiohttp] Creating custom SSL context. Cert: %s, Insecure: %s", self.log_prefix, has_cert, insecure_ssl)
             
-            # Use PROTOCOL_TLS_CLIENT to negotiate, but cap at TLS 1.2
-            # because Samsung ACs hang when receiving a TLS 1.3 Client Hello.
-            protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
-            context = ssl.SSLContext(protocol)
-            
-            # If insecure_ssl or mTLS (self-signed), we don't verify hostname/chain
-            context.check_hostname = False
-            context.verify_mode = ssl.CERT_NONE
-
-            # Replicate the 'requests' logic to allow ALL ciphers (fixes Handshake Failure)
-            context.set_ciphers("ALL:@SECLEVEL=0")
-            
-            # Cap the maximum version to TLS 1.2 to prevent the AC from hanging
-            if hasattr(ssl, 'TLSVersion'):
-                if hasattr(ssl.TLSVersion, 'TLSv1_2'):
-                    try:
-                        context.maximum_version = ssl.TLSVersion.TLSv1_2
-                    except Exception as e:
-                        _LOGGER.debug("%s [aiohttp] Could not set TLS max version: %s", self.log_prefix, e)
-                if hasattr(ssl.TLSVersion, 'TLSv1'):
-                    try:
-                        context.minimum_version = ssl.TLSVersion.TLSv1
-                    except Exception:
-                        pass
-            
-            if has_cert:
-                _LOGGER.debug("%s [aiohttp] Loading mTLS cert from: %s", self.log_prefix, self._cert_path)
-                loop = asyncio.get_running_loop()
-                load_chain_func = partial(context.load_cert_chain, self._cert_path)
-                await loop.run_in_executor(None, load_chain_func)
-
-            # Log the configured TLS limits
-            max_ver = getattr(context, 'maximum_version', 'Unknown')
-            min_ver = getattr(context, 'minimum_version', 'Unknown')
-            _LOGGER.debug("%s [aiohttp] SSLContext configured. Min: %s, Max: %s", self.log_prefix, str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
+            import ssl
+            from .helpers import async_create_samsung_ssl_context
+            context = await async_create_samsung_ssl_context(
+                cert_path=self._cert_path if has_cert else None,
+                ciphers="ALL:@SECLEVEL=0",
+                verify_mode=ssl.CERT_NONE
+            )
             
             return context
         except Exception as e:
@@ -230,48 +203,12 @@ class ConnectionAiohttp8888(Connection):
             #_LOGGER.debug("%s [create_updated] Found and creating value-specific template: %s", self.log_prefix, template_str)
             new_connection._connection_template = Template(template_str)
         
-        # HACK: Convert static params to a connection_template string.
+        # If params are defined without an explicit connection_template, store them
+        # directly on _params. properties.py's _resolve_async_params will read them.
         elif yaml_node and CONFIG_DEVICE_CONNECTION_PARAMS in yaml_node:
-            # This is a static command (like setting a mode)
-            params = {**self._params, **yaml_node.get(CONFIG_DEVICE_CONNECTION_PARAMS, {})} # Inherit from parent
-            new_connection._params.update(params) # Store params for good practice
-            
-            # --- START OF FIX (v2) ---
-            # The template must contain all necessary keys. If a key (like 'url')
-            # is missing in the value-specific params, fall back to the base connection's params.
-            template_dict = {}
-            if 'json' in params:
-                template_dict['json'] = params['json']
-            
-            # Use the value-specific method/url if present, otherwise use the base one.
-            # --- START OF FIX ---
-            # Ensure the URL is just the path, not the full URL, to prevent duplication,
-            # UNLESS it is an absolute URL (SmartThings), in which case we keep it.
-            url_from_params = params.get('url', self._params.get('url'))
-            if url_from_params:
-                parsed = urlparse(url_from_params)
-                if parsed.scheme and parsed.netloc:
-                    # Absolute URL - Keep it entirely
-                    template_dict['url'] = url_from_params
-                else:
-                    # Relative URL - Extract path only (for legacy 8888 behavior)
-                    template_dict['url'] = parsed.path
-        
-            # --- START OF FIX ---
-            # If the method is not in the current params (common for embedded commands),
-            # explicitly fall back to the base connection's params (`self._params`).
-            template_dict['method'] = params.get('method', self._params.get('method'))
-            # --- END OF FIX ---
+            params = {**self._params, **yaml_node.get(CONFIG_DEVICE_CONNECTION_PARAMS, {})}
+            new_connection._params.update(params)
 
-            if not template_dict.get('url'):
-                _LOGGER.error("%s [create_updated] HACK FAILED: Could not determine 'url' from value-specific or base params.", self.log_prefix)
-            
-            template_str = json.dumps(template_dict)
-            #_LOGGER.debug("%s [create_updated] HACK: Converting static params to template: %s", self.log_prefix, template_str)
-            new_connection._connection_template = Template(template_str)
-            # --- END OF FIX (v2) ---
-        #else:
-        #    _LOGGER.debug("%s [create_updated] No 'connection_template' or 'params' found in this YAML node.", self.log_prefix)
 
         # --- START: Replicate embedded command logic from connection_request.py ---
         # This MUST run AFTER the parent's params have been processed.
@@ -314,18 +251,15 @@ class ConnectionAiohttp8888(Connection):
             probe_headers = {"Authorization": f"Bearer {current_token}"}
 
             # --- START OF FIX: Use the shared state's SSL context ---
-            if not self._shared_state["ssl_context"]:
-                self._shared_state["ssl_context"] = await self._create_ssl_context()
+            # Skip SSL context creation entirely for plain HTTP test mode
+            if not self._config.get("use_http", False):
+                if not self._shared_state["ssl_context"]:
+                    self._shared_state["ssl_context"] = await self._create_ssl_context()
 
-            # If create_ssl_context returned None (no cert), we might still want to proceed if this is a
-            # SmartThings device which doesn't need mTLS.
-            # However, for 8888 devices, no cert = failure.
-            # We can detect this by checking if we have a token (SmartThings usually relies on token).
-            
             ssl_ctx = self._shared_state["ssl_context"]
             if ssl_ctx is None:
                 # Logic for "insecure" / no-cert connection
-                ssl_ctx = False 
+                ssl_ctx = False
 
             if True: #Indent block 
             # --- END OF FIX ---
@@ -333,14 +267,23 @@ class ConnectionAiohttp8888(Connection):
                     _LOGGER.debug("%s [aiohttp_probe] Probing connection...", self.log_prefix)
                     
                     # --- START OF FIX: Generalize Probe URL ---
-                    probe_url = f"https://{self._ip_address}:8888/devices"
+                    from homeassistant.const import CONF_PORT
+                    port = self._config.get(CONF_PORT, "8888")
+                    protocol = "http" if self._config.get("use_http", False) else "https"
+                    probe_url = f"{protocol}://{self._ip_address}:{port}/devices"
                     if self._params and self._params.get("url") and str(self._params.get("url")).startswith("http"):
                         probe_url = self._params.get("url")
                         _LOGGER.debug("%s [aiohttp_probe] Detected absolute URL, probing: %s", self.log_prefix, probe_url)
+                        
+                    # --- START OF FIX: Format probe URL ---
+                    probe_url = self._format_url(probe_url)
+                    # --- END OF FIX ---
                     # --- END OF FIX ---
 
                     # Update timeout to be more granular
-                    async with self._session.request("GET", probe_url, headers=probe_headers, ssl=self._shared_state["ssl_context"], timeout=aiohttp.ClientTimeout(total=10, sock_read=5)) as response:
+                    # If using HTTP for tests, disable SSL context requirement
+                    test_ssl_ctx = False if protocol == "http" else self._shared_state["ssl_context"]
+                    async with self._session.request("GET", probe_url, headers=probe_headers, ssl=test_ssl_ctx, timeout=aiohttp.ClientTimeout(total=10, sock_read=5)) as response:
                         if response.status in (200, 401, 403, 405): # Added 405 for Method Not Allowed (probing POST with GET)
                             # Attempt to log the negotiated TLS version
                             try:
@@ -418,21 +361,46 @@ class ConnectionAiohttp8888(Connection):
             # Retrieve the shared SSL context (should be initialized by _try_connection)
             ssl_context = self._shared_state.get("ssl_context")
             
-            # Create a dedicated session with the same timeout config as the global one
-            # We use a custom connector with a long keepalive timeout to mimic the shared one
-            # during the "active" phase (before we explicitly close it).
-            # --- START OF FIX: Inject SSL Context into Connector to force reuse ---
-            # Passing ssl=ssl_context ensures the connector treats connections as reusable
-            # for this specific SSL configuration.
-            # We also set limit=1 to enforce serial execution and prevent concurrent connections.
-            connector = aiohttp.TCPConnector(keepalive_timeout=75, ssl=ssl_context, limit=1)
-            # --- END OF FIX ---
+            # For plain HTTP test mode, use a simple connector with no SSL
+            if self._config.get("use_http", False):
+                connector = aiohttp.TCPConnector(keepalive_timeout=75, limit=1)
+            else:
+                connector = aiohttp.TCPConnector(keepalive_timeout=75, ssl=ssl_context, limit=1)
             timeout = aiohttp.ClientTimeout(total=30, connect=10)
             local_session = aiohttp.ClientSession(connector=connector, timeout=timeout)
             self._shared_state["local_session"] = local_session
-            _LOGGER.debug("%s [aiohttp] Created new local session (ID: %s) with connector (ID: %s) and fixed SSL Context.", self.log_prefix, id(local_session), id(connector))
+            _LOGGER.debug("%s [aiohttp] Created new local session (ID: %s) with connector (ID: %s).", self.log_prefix, id(local_session), id(connector))
         
         return self._shared_state["local_session"]
+
+    def _format_url(self, url: str) -> str:
+        """
+        Replaces placeholders in the URL with actual values from configuration.
+        Matches the behavior of ConnectionRequestBase._format_url.
+        """
+        from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PORT
+        
+        # In aiohttp engine, _ip_address is the primary source of truth for host.
+        # Fall back to _params if not available for some reason.
+        host = self._ip_address if hasattr(self, "_ip_address") and self._ip_address else self._params.get(CONF_HOST, "")
+        
+        if "__CLIMATE_IP_HOST__" in url:
+            url = url.replace("__CLIMATE_IP_HOST__", host)
+            
+        if "__CLIMATE_IP_MAC__" in url:
+            url = url.replace("__CLIMATE_IP_MAC__", self._params.get(CONF_MAC, ""))
+            
+        # Ensure we don't accidentally send traffic to port 8888 if the config says otherwise.
+        # This is needed because samsungrac.yaml hardcodes :8888 in its URLs.
+        if ":8888/" in url:
+            port = self._config.get(CONF_PORT, "8888")
+            url = url.replace(":8888/", f":{port}/")
+            
+        # Support HTTP replacement for tests against the emulator
+        if self._config.get("use_http", False):
+            url = url.replace("https://", "http://")
+            
+        return url
 
     async def _async_execute_request(
         self,
@@ -466,23 +434,26 @@ class ConnectionAiohttp8888(Connection):
         if getattr(self, "_force_close_connection", False):
             req_headers["Connection"] = "close"
 
-        # --- FIX: REMOVE FALLBACK LOGIC ---
-        # We only use HTTPS (mTLS)
-        # --- START OF FIX: Always use the shared SSL context ---
         ssl_context = self._shared_state.get("ssl_context")
-        # --- START OF FIX: URL Handling Generalization ---
         # Detect if the path is actually an absolute URL (for SmartThings).
         if url_path and url_path.startswith("http"):
             base_url = "" # No base URL needed
             # Provide a default ssl_context (unverified) if one wasn't created via mTLS probe
             if not ssl_context:
-                # Use _create_ssl_context to get the correct lenient context for insecure_ssl=True
                 ssl_context = await self._create_ssl_context()
         else:
-            base_url = f"https://{self._ip_address}:8888"
-        # --- END OF FIX ---
+            from homeassistant.const import CONF_PORT
+            port = self._config.get(CONF_PORT, "8888")
+            base_url = f"https://{self._ip_address}:{port}"
 
         full_url = f"{base_url}{url_path}"
+        full_url = self._format_url(full_url)
+        
+        # If the final URL is plain HTTP (e.g. test mode), don't use SSL
+        if full_url.startswith("http://"):
+            ssl_context = False
+        
+
 
         try:
             # --- START OF FIX: Strict Serialization with Lock ---
@@ -511,7 +482,7 @@ class ConnectionAiohttp8888(Connection):
                     url=full_url,
                     headers=req_headers,
                     data=data,
-                    ssl=ssl_context,
+                    ssl=ssl_context,  # False for http://, SSLContext for https://
                     timeout=aiohttp.ClientTimeout(total=10),
                 ) as response:
                 
@@ -627,7 +598,7 @@ class ConnectionAiohttp8888(Connection):
                             # Execute the embedded command by calling its own async_execute method.
                             # This ensures it is fully initialized and uses its own specific parameters.
                             await self._embedded_command.async_execute(
-                                method=embedded_params.get('method'), url_path=embedded_params.get('url'),
+                                method=embedded_params.get('method'), url=embedded_params.get('url'),
                                 data=embedded_data, headers=embedded_params.get('headers', headers),
                                 device_state=device_state)
                             # --- END OF FIX ---
@@ -687,20 +658,6 @@ class ConnectionAiohttp8888(Connection):
 
         return await self._async_execute_request(method, url, data, headers, _is_probe=_is_probe, _is_poll=_is_poll)
 
-    def check_execute_condition(self, device_state):
-        """Replicates the condition check from connection_request.py for async."""
-        do_execute = True
-        if hasattr(self, 'condition_template') and self.condition_template is not None:
-            _LOGGER.debug("%s Evaluating execute condition for a command.", self.log_prefix)
-            try:
-                # The template expects '1' for true.
-                rendered_condition = self.condition_template.render(device_state=device_state)
-                _LOGGER.debug("%s Execute condition result: %s", self.log_prefix, rendered_condition)
-                do_execute = str(rendered_condition).strip() == "1"
-            except Exception as e:
-                _LOGGER.error("%s Error evaluating execute condition, executing command anyway. Error: %s", self.log_prefix, e, exc_info=True)
-                do_execute = True
-        return do_execute
 
     async def close(self):
         """

--- a/custom_components/climate_ip/connection_raw.py
+++ b/custom_components/climate_ip/connection_raw.py
@@ -74,26 +74,12 @@ class ConnectionRaw8888(Connection):
             from jinja2 import Template
             new_connection._connection_template = Template(template_str)
 
-        # Convert static params to a template (HACK for legacy configs)
+        # If params are defined without an explicit connection_template, store them
+        # directly on _params. properties.py's _resolve_async_params will read them.
         elif yaml_node and CONFIG_DEVICE_CONNECTION_PARAMS in yaml_node:
             params = {**getattr(self, "_params", {}), **yaml_node.get(CONFIG_DEVICE_CONNECTION_PARAMS, {})}
             new_connection._params = params
-            template_dict = {}
-            if "json" in params:
-                template_dict["json"] = params["json"]
-            url_from_params = params.get("url", getattr(self, "_params", {}).get("url"))
-            if url_from_params:
-                template_dict["url"] = urlparse(url_from_params).path
-            template_dict["method"] = params.get("method", getattr(self, "_params", {}).get("method"))
-            if not template_dict.get("url"):
-                # Use self.log_prefix for consistency, even if it's not fully initialized yet.
-                _LOGGER.error(
-                    "%s Could not determine 'url' from params during template hack.",
-                    self.log_prefix,
-                )
-            template_str = json.dumps(template_dict)
-            from jinja2 import Template
-            new_connection._connection_template = Template(template_str)
+
 
         # Embedded commands handling
         if yaml_node and CONFIG_DEVICE_CONNECTION in yaml_node:
@@ -350,24 +336,6 @@ class ConnectionRaw8888(Connection):
         # return a tuple of (resp, error) both set to None to indicate no response.
         return None, None
 
-    def check_execute_condition(self, device_state):
-        """Replicates the condition check from connection_request.py for async."""
-        do_execute = True
-        if hasattr(self, "condition_template") and self.condition_template is not None:
-            _LOGGER.debug("%s Evaluating execute condition for a command.", self.log_prefix)
-            try:
-                rendered_condition = self.condition_template.render(device_state=device_state)
-                _LOGGER.debug("%s Execute condition result: %s", self.log_prefix, rendered_condition)
-                do_execute = str(rendered_condition).strip() == "1"
-            except Exception as e:
-                _LOGGER.error(
-                    "%s Error evaluating execute condition, executing command anyway. Error: %s",
-                    self.log_prefix,
-                    e,
-                    exc_info=True,
-                )
-                do_execute = True
-        return do_execute
 
     async def close(self):
         """

--- a/custom_components/climate_ip/connection_request.py
+++ b/custom_components/climate_ip/connection_request.py
@@ -59,29 +59,11 @@ class SamsungHTTPAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
-        protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
-        ssl_context = ssl.SSLContext(protocol)
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-        ssl_context.set_ciphers("ALL:@SECLEVEL=0")
-        
-        # Cap the maximum version to TLS 1.2 to prevent the AC from hanging
-        if hasattr(ssl, 'TLSVersion'):
-            if hasattr(ssl.TLSVersion, 'TLSv1_2'):
-                try:
-                    ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
-                except Exception as e:
-                    _LOGGER.debug("[SamsungHTTPAdapter] Could not set TLS max version: %s", e)
-            if hasattr(ssl.TLSVersion, 'TLSv1'):
-                try:
-                    ssl_context.minimum_version = ssl.TLSVersion.TLSv1
-                except Exception:
-                    pass
-
-        # Log the configured TLS limits
-        max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
-        min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
-        _LOGGER.debug("[SamsungHTTPAdapter] SSLContext configured. Min: %s, Max: %s", str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
+        from .helpers import create_samsung_ssl_context
+        ssl_context = create_samsung_ssl_context(
+            ciphers="ALL:@SECLEVEL=0",
+            verify_mode=ssl.CERT_NONE
+        )
 
         pool_kwargs["ssl_context"] = ssl_context
         
@@ -278,23 +260,6 @@ class ConnectionRequestBase(Connection):
 
         return True
 
-    def check_execute_condition(self, device_state):
-        do_execute = True
-        if self.condition_template is not None:
-            _LOGGER.debug("%s Evaluating execute condition", self.log_prefix)
-            try:
-                rendered_condition = self.condition_template.render(
-                    device_state=device_state
-                )
-                _LOGGER.debug("%s Execute condition result: %s", self.log_prefix, rendered_condition)
-                do_execute = rendered_condition == "1"
-            except:
-                _LOGGER.error(
-                    "%s Error evaluating execute condition, executing command anyway", self.log_prefix
-                )
-                do_execute = True
-
-        return do_execute
 
     def execute_internal(self, template, value, device_state, device_id=None) -> (json, bool, int):
         """Internal synchronous method to execute the HTTP request with retries."""
@@ -634,19 +599,11 @@ class ConnectionRequest(ConnectionRequestBase):
     def create_updated(self, node):
         c = ConnectionRequest(None, _LOGGER, session=self._session)
         
-        # --- START OF MODIFICATION: Topology Debugging ---
-        _LOGGER.debug(
-            "%s [Topology] create_updated: Creating child (ID=%s) from parent (ID=%s).",
-            self.log_prefix, id(c), id(self)
-        )
-        # --- END OF MODIFICATION ---
-        
         c.load_from_yaml(node, self)
         
         # --- START OF FIX: Child Propagation ---
         # Register this new instance as a child so it receives session updates
         self._children.append(c)
-        _LOGGER.debug("%s [Session Propagation] Registered property connection via create_updated.", self.log_prefix)
         # --- END OF FIX ---
         
         return c

--- a/custom_components/climate_ip/connection_request_tls_auto.py
+++ b/custom_components/climate_ip/connection_request_tls_auto.py
@@ -191,23 +191,6 @@ class ConnectionRequestBase(Connection):
 
         return True
 
-    def check_execute_condition(self, device_state):
-        do_execute = True
-        if self.condition_template is not None:
-            _LOGGER.debug("%s Evaluating execute condition for command.", self.log_prefix)
-            try:
-                rendered_condition = self.condition_template.render(
-                    device_state=device_state
-                )
-                _LOGGER.debug("%s Execute condition result: %s", self.log_prefix, rendered_condition)
-                do_execute = rendered_condition == "1"
-            except Exception as e:
-                _LOGGER.error(
-                    "%s Error evaluating execute condition, executing command anyway. Error: %s", self.log_prefix, e, exc_info=True
-                )
-                do_execute = True
-
-        return do_execute
 
     def execute_internal(self, template, value, device_state, device_id=None) -> Tuple[Any, bool, int]:
         import warnings

--- a/custom_components/climate_ip/controller_yaml.py
+++ b/custom_components/climate_ip/controller_yaml.py
@@ -99,8 +99,13 @@ class YamlController(ClimateController):
         
         self._config = config
         self._yaml = config.get(CONF_CONFIG_FILE)
-        self._ip_address = config.get(CONF_IP_ADDRESS, None)
-        self._device_id = config.get(CONF_DEVICE_ID, None) 
+        
+        # --- START OF FIX: Handle tests vs real integration keys ---
+        # The configuration flow uses CONF_IP_ADDRESS, but our tests and older configs might use CONF_HOST
+        self._ip_address = config.get(CONF_IP_ADDRESS) or config.get("host") # "host" == CONF_HOST
+        # --- END OF FIX ---
+        
+        self._device_id = config.get(CONF_DEVICE_ID, None)
         self._token = config.get(CONF_TOKEN, None)
         self._unique_id = config.get("unique_id") or config.get(CONF_MAC) or self._ip_address
 
@@ -268,15 +273,11 @@ class YamlController(ClimateController):
         """
         if self._is_fully_initialized or not self._raw_yaml_config:
             return
-    
-        _LOGGER.debug("%s Finalizing initialization with discovered device_id: %s", self.log_prefix, self._device_id)
         
         # Use the context-aware cache
         if self._device_id in self._parsed_yaml_cache:
-            _LOGGER.debug("%s [Cache] Using cached YAML for device_id: %s", self.log_prefix, self._device_id)
             yaml_device = self._parsed_yaml_cache[self._device_id]
         else:
-            _LOGGER.debug("%s [Cache] Parsing and caching YAML for device_id: %s", self.log_prefix, self._device_id)
             final_yaml_str = stream_wrapper(
                 self._raw_yaml_config, self._token, self._ip_address, self._device_id
             )
@@ -319,15 +320,11 @@ class YamlController(ClimateController):
                 # Add support for static 'unit_of_measurement' in attributes, same as in sensors.
                 has_setter = hasattr(prop, 'set_unit_of_measurement')
                 has_unit_key = 'unit_of_measurement' in nodes[key]
-                _LOGGER.debug("%s Attribute '%s': has_setter=%s, has_unit_key=%s", self.log_prefix, key, has_setter, has_unit_key)
+                has_unit_key = 'unit_of_measurement' in nodes[key]
 
                 if has_setter and has_unit_key:
                     unit_value = nodes[key]['unit_of_measurement']
-                    _LOGGER.debug("%s Setting static unit for attribute '%s' to '%s'", self.log_prefix, key, unit_value)
                     prop.set_unit_of_measurement(unit_value)
-                else:
-                    if has_setter and not has_unit_key:
-                        _LOGGER.debug("%s Attribute '%s' supports units, but 'unit_of_measurement' not found in its YAML config.", self.log_prefix, key)
                 # --- END OF MODIFICATION ---
         
         # --- ADD THIS BLOCK TO LOAD SENSORS ---
@@ -468,9 +465,7 @@ class YamlController(ClimateController):
                      _LOGGER.debug("%s [Init] Retrieved ConfigEntry. Options: %s", self.log_prefix, entry.options)
                      if entry.options:
                         conn_method = entry.options.get(CONF_CONN_METHOD, conn_method)
-                        _LOGGER.debug("%s [Init] Connection method resolved to: %s", self.log_prefix, conn_method)
             # --- END OF FIX ---
-
             if conn_method == CONN_METHOD_AIOHTTP:
                 _LOGGER.info("%s Using 'Modern (aiohttp)' connection engine (from options)", self.log_prefix)
                 connection_node[CONFIG_DEVICE_CONNECTION_TYPE] = "samsung_8888_aiohttp"
@@ -486,12 +481,6 @@ class YamlController(ClimateController):
         # This call will now create the correct connection type based on the logic above
         # --- START OF MODIFICATION (Milestone 3) ---
 
-
-        # --- START: Logic moved from connection.py ---
-        key = self.unique_id
-        if not key:
-            _LOGGER.error("%s Cannot create a unique connection without a unique_id", self.log_prefix)
-            return False
 
         # --- START: Logic moved from connection.py ---
         key = self.unique_id
@@ -586,6 +575,46 @@ class YamlController(ClimateController):
             raise UpdateFailed("State getter is not initialized, cannot update state.")
         # --- END OF FIX ---
 
+        # --- DUAL-SPEED BACKOFF: PING GATE ---
+        # Exclude port 2878 devices since they manage their own ping gate in `samsung_2878.py`
+        if self._config.get(CONF_DEVICE_TYPE) != DEVICE_TYPE_SAMSUNG_2878 and getattr(self, "_ip_address", None):
+            try:
+                from .helpers import async_check_network_reachability
+                network_reachable = await async_check_network_reachability(self._ip_address, self.log_prefix)
+                if not network_reachable:
+                    # Increment failure counter explicitly for ping failures
+                    self._consecutive_connection_errors += 1
+                    
+                    # Create a repair issue if the device is persistently offline (3 ping failures)
+                    if self._consecutive_connection_errors == 3 and getattr(self, 'hass', None):
+                        try:
+                            from homeassistant.helpers.issue_registry import async_create_issue, IssueSeverity
+                            async_create_issue(
+                                self.hass,
+                                "climate_ip",
+                                f"connection_failed_{self._ip_address}",
+                                is_fixable=False,
+                                severity=IssueSeverity.WARNING,
+                                translation_key="connection_failed",
+                                translation_placeholders={
+                                    "host": self._ip_address,
+                                    "name": getattr(self, '_name', None) or self._ip_address
+                                }
+                            )
+                        except Exception as e:
+                            _LOGGER.debug("%s Failed to create repair issue on ping timeout: %s", self.log_prefix, e)
+
+                    if self._consecutive_connection_errors >= 2:
+                        raise CannotConnect("Host unreachable (ICMP ping failed). Device is persistently offline.")
+                    else:
+                        raise CannotConnect("Host unreachable (ICMP ping failed).")
+            except Exception as diag_err:
+                # If ping check throws some internal exception, don't fail the execution, let it try the socket
+                if isinstance(diag_err, CannotConnect):
+                    raise # Bubble up our intentionally raised exception
+                _LOGGER.debug("%s Network diagnostic failed: %s", self.log_prefix, diag_err)
+        # -------------------------------------
+
         try:
             full_device_state = await self._state_getter.async_update_state(None, self._debug)
             
@@ -596,7 +625,21 @@ class YamlController(ClimateController):
                     self.log_prefix, 
                     self._consecutive_connection_errors
                 )
-            self._consecutive_connection_errors = 0
+                self._consecutive_connection_errors = 0
+                
+                # --- START OF MODIFICATION: Resolve Repair Issue ---
+                if getattr(self, 'hass', None):
+                    try:
+                        from homeassistant.helpers.issue_registry import async_delete_issue
+                        async_delete_issue(
+                            self.hass,
+                            "climate_ip",
+                            f"connection_failed_{self._ip_address}"
+                        )
+                        _LOGGER.debug("%s Successfully resolved/deleted repair issue on reconnection.", self.log_prefix)
+                    except Exception as e:
+                        _LOGGER.debug("%s Failed to delete repair issue: %s", self.log_prefix, e)
+                # --- END OF MODIFICATION ---
             # --------------------------------------
 
         except AuthError:
@@ -642,7 +685,10 @@ class YamlController(ClimateController):
 
         except (RequestException, CannotConnect) as e:
             # --- TRANSIENT ERROR SUPPRESSION ---
-            self._consecutive_connection_errors += 1
+            if "persistently offline" in str(e):
+                self._consecutive_connection_errors = 2 # Force failure bypasses cache
+            else:
+                self._consecutive_connection_errors += 1
             
             if self._consecutive_connection_errors < 2 and self._cached_device_state:
                 _LOGGER.debug(
@@ -652,6 +698,25 @@ class YamlController(ClimateController):
                     e
                 )
                 return self._cached_device_state
+            
+            # Create a repair issue if the device is persistently offline (3 failures on the socket)
+            if self._consecutive_connection_errors == 3 and getattr(self, 'hass', None):
+                try:
+                    from homeassistant.helpers.issue_registry import async_create_issue, IssueSeverity
+                    async_create_issue(
+                        self.hass,
+                        "climate_ip",
+                        f"connection_failed_{self._ip_address}",
+                        is_fixable=False,
+                        severity=IssueSeverity.WARNING,
+                        translation_key="connection_failed",
+                        translation_placeholders={
+                            "host": self._ip_address,
+                            "name": getattr(self, '_name', None) or self._ip_address
+                        }
+                    )
+                except Exception as issue_e:
+                    _LOGGER.debug("%s Failed to create repair issue on socket timeout: %s", self.log_prefix, issue_e)
             
             # If we reached here, it's either the 2nd failure OR we have no cache.
             # We raise the exception to mark the entity as unavailable.

--- a/custom_components/climate_ip/coordinator.py
+++ b/custom_components/climate_ip/coordinator.py
@@ -65,6 +65,7 @@ class SamsungClimateCoordinator(DataUpdateCoordinator):
             name=f"Samsung Climate {self.log_prefix}",
             update_interval=update_interval,
             always_update=True,
+            config_entry=entry,
         )
 
         # --- START OF FIX ---
@@ -136,14 +137,14 @@ class SamsungClimateCoordinator(DataUpdateCoordinator):
             max_strikes = 3
             
             if self._consecutive_failures < max_strikes:
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "%s Transient connection failure (%s/%s). Preserving last known state. Error: %s",
                     self.log_prefix, self._consecutive_failures, max_strikes, err
                 )
                 # Return the last known data to prevent 'Unavailable' state
                 return self.data if self.data else self._create_device_state()
             else:
-                _LOGGER.error("%s Persistent connection failure after %s attempts. Marking entity as unavailable.", self.log_prefix, max_strikes)
+                _LOGGER.debug("%s Persistent connection failure after %s attempts. Marking entity as unavailable.", self.log_prefix, max_strikes)
                 raise UpdateFailed(f"Failed to fetch device state after {max_strikes} attempts: {err}") from err
             # --- END OF FIX ---
 

--- a/custom_components/climate_ip/helpers.py
+++ b/custom_components/climate_ip/helpers.py
@@ -57,6 +57,82 @@ def stream_wrapper(data: str, token: str | None, ip_address: str | None, device_
         data = data.replace("__DEVICE_ID__", str(device_id))
     return data
 
+def get_tls_version_name(version_code: Any) -> str:
+    """Safely convert a TLS version code to its friendly name."""
+    import ssl
+    if hasattr(ssl, 'TLSVersion'):
+        try:
+            return ssl.TLSVersion(version_code).name
+        except ValueError:
+            return str(version_code)
+    return str(version_code)
+
+def create_samsung_ssl_context(
+    cert_path: str | None = None,
+    ciphers: str = "ALL:@SECLEVEL=0",
+    verify_mode: Any = None,
+) -> Any:
+    """
+    Creates the standardized SSL context for Samsung devices.
+    Enforces PROTOCOL_TLS_CLIENT, sets verify mode, loads ciphers,
+    and caps the maximum TLS version to TLSv1_2 to prevent the AC handshake bug.
+    """
+    import ssl
+    import asyncio
+    
+    protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
+    context = ssl.SSLContext(protocol)
+    
+    context.set_ciphers(ciphers)
+    context.check_hostname = False
+    if verify_mode is not None:
+        context.verify_mode = verify_mode
+    else:
+        context.verify_mode = ssl.CERT_NONE
+        
+    if hasattr(ssl, 'TLSVersion'):
+        if hasattr(ssl.TLSVersion, 'TLSv1_2'):
+            try:
+                context.maximum_version = ssl.TLSVersion.TLSv1_2
+            except Exception as e:
+                _LOGGER.debug("Could not set TLS max version: %s", e)
+        if hasattr(ssl.TLSVersion, 'TLSv1'):
+            try:
+                context.minimum_version = ssl.TLSVersion.TLSv1
+            except Exception:
+                pass
+
+    if cert_path:
+        context.load_verify_locations(cafile=cert_path)
+        context.load_cert_chain(cert_path)
+
+    min_ver = get_tls_version_name(getattr(context, 'minimum_version', 'Unknown'))
+    max_ver = get_tls_version_name(getattr(context, 'maximum_version', 'Unknown'))
+    # _LOGGER.debug("Shared SSLContext configured. Min: %s, Max: %s, Cert: %s", min_ver, max_ver, bool(cert_path))
+
+    return context
+
+async def async_create_samsung_ssl_context(
+    cert_path: str | None = None,
+    ciphers: str = "ALL:@SECLEVEL=0",
+    verify_mode: Any = None,
+) -> Any:
+    """
+    Async wrapper for create_samsung_ssl_context.
+    Executes the blocking disk I/O parts of the SSL context creation
+    in the default executor to avoid blocking the Home Assistant event loop.
+    """
+    import asyncio
+    import functools
+    loop = asyncio.get_running_loop()
+    func = functools.partial(
+        create_samsung_ssl_context,
+        cert_path=cert_path,
+        ciphers=ciphers,
+        verify_mode=verify_mode
+    )
+    return await loop.run_in_executor(None, func)
+
 def mask_sensitive_data(data: Any) -> Any:
     """
     Recursively mask sensitive data in a dictionary or list.
@@ -85,3 +161,60 @@ def mask_sensitive_data(data: Any) -> Any:
         data = re.sub(r'(DUID=")([^"]+)(")', r'\1***\3', data)
         return data
     return data
+
+async def async_check_network_reachability(host: str, log_prefix: str = "") -> bool:
+    """Check if the device is reachable on the network.
+    Uses system ping to verify if the host is alive.
+    Results are logged at DEBUG level to help diagnose disconnections.
+    """
+    import asyncio
+    import os
+
+    process = None
+    try:
+        # -c 1 = 1 packet, -W 2 = 2 seconds timeout
+        # Use 'ping' for Linux/macOS and fallback behavior for Windows if needed
+        ping_cmd = ["ping", "-c", "1", "-W", "2", host]
+        
+        # Windows ping commands are slightly different: -n 1 for count, -w 2000 for timeout
+        if os.name == 'nt':
+            ping_cmd = ["ping", "-n", "1", "-w", "2000", host]
+
+        process = await asyncio.create_subprocess_exec(
+            *ping_cmd,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL
+        )
+        
+        # Wait for ping to finish with a safety timeout
+        await asyncio.wait_for(process.wait(), timeout=3.0)
+        
+        if process.returncode == 0:
+            _LOGGER.debug(
+                "%s Network diagnostic: Host %s responded to ICMP ping. "
+                "Network is OK.",
+                log_prefix, host
+            )
+            return True
+        else:
+            _LOGGER.debug(
+                "%s Network diagnostic: Host %s is NOT reachable (ICMP ping failed). "
+                "Check that the device is powered on and connected to your Wi-Fi.",
+                log_prefix, host
+            )
+            return False
+    except asyncio.TimeoutError:
+        if process:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+        _LOGGER.debug(
+            "%s Network diagnostic: Host %s is NOT reachable (Ping timed out). "
+            "Check that the device is powered on and connected to your Wi-Fi.",
+            log_prefix, host
+        )
+        return False
+    except Exception as e:
+        _LOGGER.debug("%s Network diagnostic (ping) error: %s", log_prefix, e)
+        return True # Fallback to trying connection if ping fails for unknown reasons

--- a/custom_components/climate_ip/manifest.json
+++ b/custom_components/climate_ip/manifest.json
@@ -13,5 +13,5 @@
     "requests>=2.21.0",
     "xmltodict>=0.13.0"
   ],
-  "version": "9.1.0"
+  "version": "9.1.1"
 }

--- a/custom_components/climate_ip/properties.py
+++ b/custom_components/climate_ip/properties.py
@@ -436,6 +436,67 @@ class DeviceOperation(DeviceProperty):
     def __init__(self, name, connection, controller, status_getter=None):
         super(DeviceOperation, self).__init__(name, connection, controller, status_getter)
 
+    def _resolve_async_params(self, connection, dev_value, duid: Optional[str] = None) -> Optional[dict]:
+        """Resolve the final {method, url, json, headers} dict for an async command.
+
+        Checks both ``_connection_template`` (rendered) and ``_params`` (dict)
+        so that callers work whether or not the params→template HACK in
+        ``create_updated`` has serialised the params into a template first.
+
+        Strategy:
+        1. Render the *property's own* ``connection_template`` (e.g. for numeric
+           operations like temperature) if present — this is the operation-specific
+           part and always takes precedence for ``json``.
+        2. Fall back to ``connection._connection_template`` if no property template.
+        3. In either case, fill missing ``method``/``url``/``headers`` from the
+           connection's ``_params`` dict (or a parent connection_template), giving
+           the operation-specific values priority.
+
+        Returns a dict with keys ``method``, ``url``, ``json`` (optional),
+        ``headers`` (optional); or ``{'_raw': <str>}`` for non-JSON payloads;
+        or ``None`` if no parameters could be resolved at all.
+        """
+        render_ctx = {'value': dev_value, 'device_id': duid, 'duid': duid}
+
+        # ------------------------------------------------------------------ #
+        # Step 1 – resolve the "operation" part (value-specific json/url)    #
+        # ------------------------------------------------------------------ #
+        operation_params: dict = {}
+        template_to_use = self.connection_template or getattr(connection, '_connection_template', None)
+
+        if template_to_use:
+            rendered = template_to_use.render(**render_ctx)
+            try:
+                operation_params = json.loads(rendered)
+            except json.JSONDecodeError:
+                # Non-JSON payload (e.g. XML for 2878) – return as raw.
+                return {'_raw': rendered}
+        else:
+            # No template at all – read directly from _params.
+            operation_params = dict(getattr(connection, '_params', {}))
+
+        if not operation_params:
+            _LOGGER.error("%s [_resolve_async_params] No params or template found.", self.log_prefix)
+            return None
+
+        # ------------------------------------------------------------------ #
+        # Step 2 – resolve the "base" part (method + url from parent conn)   #
+        # ------------------------------------------------------------------ #
+        base_params: dict = {}
+        base_template = getattr(connection, '_connection_template', None)
+        if base_template and base_template is not template_to_use:
+            try:
+                base_params = json.loads(base_template.render(**render_ctx))
+            except (json.JSONDecodeError, Exception):
+                pass
+        # Also honour raw _params on the connection as the ultimate fallback.
+        raw_params = getattr(connection, '_params', {})
+        fallback: dict = {**raw_params, **base_params}
+
+        # Merge: base first, then operation-specific values win.
+        merged = {**fallback, **operation_params}
+        return merged
+
     async def async_set_value(self, v, device_id: Optional[str] = None):
         """Set device property value asynchronously."""
         connection = self.get_connection(v)
@@ -450,66 +511,44 @@ class DeviceOperation(DeviceProperty):
                 current_full_state = self._status_getter.value
             # --- END OF FIX ---
 
-        # --- START: Logic to handle async nested commands ---
+        # --- START: Logic to handle async native commands ---
         if connection.is_async_native:
-
             try:
-                # The `async_execute` method in ConnectionAiohttp8888 will handle its embedded command internally.
-                # We just need to call it once with the parameters for the *main* command.                
-                # --- START OF SOLUTION: Use the property's template, not the connection's ---
-                # The property's connection_template (self) is the one loaded from YAML
-                # for numeric/temperature operations. The connection's one might be empty.
-                template_to_use = self.connection_template or getattr(connection, '_connection_template', None)
-                # --- END OF SOLUTION ---
-                if not template_to_use: # Now we check after trying both sources
-                    _LOGGER.error("%s [async_set_value] Main command is missing a connection template.", self.log_prefix)
-                    return False
-
-                # --- START OF SOLUTION: Merge base and template parameters ---
-                # Render the operation-specific template (e.g., for temperature).
-                
-                # Retrieve DUID for 2878 devices
+                # Resolve DUID for 2878 devices
                 duid_for_render = device_id
                 if not duid_for_render and hasattr(self._controller, 'device_id') and self._controller.device_id:
-                     duid_for_render = self._controller.device_id
-                
-                # Fallback to connection config if not found in controller (unlikely after fix)
+                    duid_for_render = self._controller.device_id
                 if not duid_for_render and hasattr(connection, '_cfg') and hasattr(connection._cfg, 'duid') and connection._cfg.duid:
-                     duid_for_render = connection._cfg.duid
-                
-                rendered_params_str = template_to_use.render(value=self.convert_hass_to_dev(v), device_id=duid_for_render, duid=duid_for_render)
-                try:
-                    operation_params = json.loads(rendered_params_str)
+                    duid_for_render = connection._cfg.duid
 
-                    # Get the base parameters from the connection (which contain method and url).
-                    # The 'hack' in `create_updated` ensures that `_connection_template` exists.
-                    base_template = getattr(connection, '_connection_template', None)
-                    base_params_str = base_template.render() if base_template else "{}"
-                    base_params = json.loads(base_params_str)
+                dev_value = self.convert_hass_to_dev(v)
+                params = self._resolve_async_params(connection, dev_value, duid_for_render)
 
-                    # Merge the parameters, giving priority to the operation-specific ones.
-                    params = {**base_params, **operation_params}
-                    # --- END OF SOLUTION ---
-                    data_payload = json.dumps(params.get('json')) if 'json' in params else None
+                if params is None:
+                    _LOGGER.error("%s [async_set_value] Could not resolve command parameters.", self.log_prefix)
+                    return False
 
-                    response, _ = await connection.async_execute(params.get('method'), params.get('url'), data_payload, params.get('headers'), device_state=current_full_state)
-                    return response is not None
-                except json.JSONDecodeError:
-                    # --- START OF FIX: Handle non-JSON payloads (e.g., XML for 2878) ---
-                    # If the template renders to something that isn't JSON (like <Request ...>),
-                    # we treat it as a raw payload and send it directly.
-                    # 2878 connection ignores method/url/headers for raw sends.
-                    _LOGGER.debug("%s [async_set_value] Payload is not JSON, assuming raw data (XML): %s", self.log_prefix, rendered_params_str)
-                    await connection.async_execute(None, None, rendered_params_str, None)
+                if params.get('_raw'):
+                    # Non-JSON payload (e.g. XML for 2878) — send as raw body
+                    _LOGGER.debug("%s [async_set_value] Sending raw (non-JSON) payload.", self.log_prefix)
+                    await connection.async_execute(None, None, params['_raw'], None)
                     return True
-                    # --- END OF FIX ---
+
+                data_payload = json.dumps(params['json']) if 'json' in params else None
+                response, _ = await connection.async_execute(
+                    params.get('method'), params.get('url'), data_payload,
+                    params.get('headers'), device_state=current_full_state
+                )
+                return response is not None
             except (CannotConnect, AuthError) as e:
-                 _LOGGER.warning("%s Failed to set value for %s: connection error: %s", self.log_prefix, self.id, e)
-                 return False
+                _LOGGER.warning("%s Failed to set value for %s: connection error: %s", self.log_prefix, self.id, e)
+                from homeassistant.exceptions import HomeAssistantError
+                raise HomeAssistantError(f"Connection error: could not set value for {self.id}") from e
             except Exception as e:
                 _LOGGER.error("%s Error during async_set_value for %s: %s", self.log_prefix, self.id, e, exc_info=True)
-                return False
-        # --- END: Logic to handle async nested commands ---
+                from homeassistant.exceptions import HomeAssistantError
+                raise HomeAssistantError(f"Unexpected error when setting {self.id}") from e
+        # --- END: Logic to handle async native commands ---
         else: # Fallback to original synchronous logic
 
             try:
@@ -527,10 +566,12 @@ class DeviceOperation(DeviceProperty):
                 return True
             except (CannotConnect, AuthError) as e:
                  _LOGGER.warning("%s Failed to set value for %s: connection error: %s", self.log_prefix, self.id, e)
-                 return False
+                 from homeassistant.exceptions import HomeAssistantError
+                 raise HomeAssistantError(f"Connection error: could not set value for {self.id}") from e
             except Exception as e:
                 _LOGGER.error("%s Error during async_set_value for %s: %s", self.log_prefix, self.id, e, exc_info=True)
-                return False
+                from homeassistant.exceptions import HomeAssistantError
+                raise HomeAssistantError(f"Unexpected error when setting {self.id}") from e
 
     def match_value(self, value):
         """Check if value matches the operation. True if the value is correct."""

--- a/custom_components/climate_ip/protocol_8888.py
+++ b/custom_components/climate_ip/protocol_8888.py
@@ -45,28 +45,11 @@ class Samsung8888Client:
 
     async def _create_ssl_context(self) -> ssl.SSLContext:
         """Configure SSL, replicating the logic from connection_request.py."""
-        # Use PROTOCOL_TLS_CLIENT to negotiate, but cap at TLS 1.2
-        # because Samsung ACs hang when receiving a TLS 1.3 Client Hello.
-        protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
-        ctx = ssl.SSLContext(protocol)
-        
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        # Use ALL:@SECLEVEL=0 as in the original code for maximum compatibility
-        ctx.set_ciphers("ALL:@SECLEVEL=0")
-        
-        # Cap the maximum version to TLS 1.2 to prevent the AC from hanging
-        if hasattr(ssl, 'TLSVersion'):
-            if hasattr(ssl.TLSVersion, 'TLSv1_2'):
-                try:
-                    ctx.maximum_version = ssl.TLSVersion.TLSv1_2
-                except Exception as e:
-                    _LOGGER.debug("%s [protocol_8888] Could not set TLS max version: %s", self.log_prefix, e)
-            if hasattr(ssl.TLSVersion, 'TLSv1'):
-                try:
-                    ctx.minimum_version = ssl.TLSVersion.TLSv1
-                except Exception:
-                    pass
+        from .helpers import async_create_samsung_ssl_context
+        ctx = await async_create_samsung_ssl_context(
+            ciphers="ALL:@SECLEVEL=0",
+            verify_mode=ssl.CERT_NONE
+        )
         
         # --- START OF FIX: Optimize SSL for low-memory devices ---
         # Disable session tickets and compression to reduce handshake overhead
@@ -104,10 +87,11 @@ class Samsung8888Client:
                     e,
                 )
         
-        # Log the configured TLS limits
-        max_ver = getattr(ctx, 'maximum_version', 'Unknown')
-        min_ver = getattr(ctx, 'minimum_version', 'Unknown')
-        _LOGGER.debug("%s [protocol_8888] SSLContext configured. Min: %s, Max: %s", self.log_prefix, str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
+        # Log the configured TLS limits using friendly names
+        from .helpers import get_tls_version_name
+        max_ver = get_tls_version_name(getattr(ctx, 'maximum_version', 'Unknown'))
+        min_ver = get_tls_version_name(getattr(ctx, 'minimum_version', 'Unknown'))
+        _LOGGER.debug("%s [protocol_8888] SSLContext configured. Min: %s, Max: %s", self.log_prefix, min_ver, max_ver)
 
         return ctx
 

--- a/custom_components/climate_ip/samsung_2878.py
+++ b/custom_components/climate_ip/samsung_2878.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_MAC, CONF_PORT, CONF_TOKEN
 from .connection import Connection, register_connection
 from .exceptions import AuthError, CannotConnect
 from .properties import DeviceProperty, register_status_getter
+from homeassistant.helpers.issue_registry import async_create_issue, async_delete_issue, IssueSeverity
 from .const import (
     CONF_CERT,
     CONFIG_DEVICE_POWER_TEMPLATE,
@@ -41,7 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 CONNECTION_TYPE_S2878 = "samsung_2878"
 CONF_DUID = "duid"
 
-INITIAL_RECONNECT_DELAY = 15
+INITIAL_RECONNECT_DELAY = 5
 MAX_RECONNECT_DELAY = 300
 RECONNECT_FACTOR = 2
 COMMAND_TIMEOUT = 20.0
@@ -364,35 +365,12 @@ class ConnectionSamsung2878(Connection):
                 ssl_context = self._ssl_context_cache.get(cache_key)
 
                 if not ssl_context:
-
-                    protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
-                    ssl_context = ssl.SSLContext(protocol)
-                    ssl_context.set_ciphers(ciphers)
-                    ssl_context.check_hostname = False
-                    ssl_context.verify_mode = verify_mode
-                    
-                    if hasattr(ssl, 'TLSVersion'):
-                        if hasattr(ssl.TLSVersion, 'TLSv1_2'):
-                            try:
-                                ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
-                            except Exception as e:
-                                _LOGGER.debug("Could not set TLS max version: %s", e)
-                        if hasattr(ssl.TLSVersion, 'TLSv1'):
-                            try:
-                                ssl_context.minimum_version = ssl.TLSVersion.TLSv1
-                            except Exception:
-                                pass
-                                
-                    if cert_path:
-                        await asyncio.to_thread(ssl_context.load_verify_locations, cafile=cert_path)
-                        await asyncio.to_thread(ssl_context.load_cert_chain, cert_path)
-
-                    # Log the configured TLS limits only once per connection cycle
-                    if not logged_ssl_config:
-                        max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
-                        min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
-                        _LOGGER.debug("%s [samsung_2878] SSLContext configured. Min: %s, Max: %s", self.log_prefix, str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
-                        logged_ssl_config = True
+                    from .helpers import async_create_samsung_ssl_context
+                    ssl_context = await async_create_samsung_ssl_context(
+                        cert_path=cert_path, 
+                        ciphers=ciphers, 
+                        verify_mode=verify_mode
+                    )
 
                     self._ssl_context_cache[cache_key] = ssl_context
 
@@ -515,6 +493,16 @@ class ConnectionSamsung2878(Connection):
         if not self._is_available:
             _LOGGER.info("%s Connection re-established", self.log_prefix)
             self._is_available = True
+            try:
+                # Clear any pending repair issues since the device came back online
+                if self._controller and getattr(self._controller, 'hass', None):
+                    async_delete_issue(
+                        self._controller.hass,
+                        "climate_ip",
+                        f"connection_failed_{self._cfg.host}"
+                    )
+            except Exception as e:
+                _LOGGER.debug("%s Could not clear repair issue: %s", self.log_prefix, e)
 
         # Request a full status update only on reconnections, not on the very first connection.
         if self._initial_connection_done:
@@ -734,6 +722,8 @@ class ConnectionSamsung2878(Connection):
         return buffer
 
 
+
+
     async def _handle_reconnection(self) -> bool:
         """Handle the reconnection process."""
         # Stateful logging: Log INFO only when the state changes from available to unavailable.
@@ -743,25 +733,128 @@ class ConnectionSamsung2878(Connection):
         else:
             _LOGGER.debug("%s Connection is down. Attempting to reconnect...", self.log_prefix)
 
+        # Run network diagnostics on every reconnect attempt to aid troubleshooting.
+        # Only attempt to open the TCP port if the ping succeeds to protect fragile ACs.
+        network_reachable = True
         try:
-            # If the handshake fails with a connection error, it returns False.
-            # We must handle this case to prevent falling through and causing an AttributeError.
-            if not await self._establish_connection_and_handshake():
-                _LOGGER.debug("%s Handshake returned False. Proceeding to retry logic.", self.log_prefix)
+            from .helpers import async_check_network_reachability
+            network_reachable = await async_check_network_reachability(self._cfg.host, self.log_prefix)
+        except Exception as diag_err:
+            _LOGGER.debug("%s Network diagnostic failed: %s", self.log_prefix, diag_err)
+
+        try:
+            # If the network is reachable, attempt handshake. Otherwise, skip to retry to protect device.
+            handshake_success = False
+            if network_reachable:
+                handshake_success = await self._establish_connection_and_handshake()
+            else:
+                _LOGGER.debug("%s Skipping port connection attempt because ICMP ping failed.", self.log_prefix)
+
+            # --- DUAL-SPEED BACKOFF LOGIC ---
+            if not network_reachable:
+                # 1. Network is fully down (router off, device unplugged, no wifi)
+                # Wait a fixed 10 seconds. Do NOT increment exponential backoff to recover quickly.
+                _LOGGER.debug("%s Host unreachable. Retrying ping in 10 seconds...", self.log_prefix)
                 self._reconnect_retries += 1
-                _LOGGER.warning("%s Connection failed. Retrying in %s seconds...", self.log_prefix, self._reconnect_delay)
+                
+                # Create a repair issue if the device is persistently offline
+                if self._reconnect_retries == 3 and self._controller and getattr(self._controller, 'hass', None):
+                    try:
+                        async_create_issue(
+                            self._controller.hass,
+                            "climate_ip",
+                            f"connection_failed_{self._cfg.host}",
+                            is_fixable=False,
+                            severity=IssueSeverity.WARNING,
+                            translation_key="connection_failed",
+                            translation_placeholders={
+                                "host": self._cfg.host,
+                                "name": getattr(self._cfg, 'name', None) or self._cfg.host
+                            }
+                        )
+                    except Exception as e:
+                        _LOGGER.debug("%s Failed to create repair issue: %s", self.log_prefix, e)
+
+                # If we've failed 2 times on the ping, force unavailability in HA
+                if self._reconnect_retries == 2:
+                    _LOGGER.error("%s AC Network is persistently offline. Forcing frontend unavailability.", self.log_prefix)
+                    if self._controller and getattr(self._controller, 'coordinator', None):
+                        self._controller.coordinator.last_update_success = False
+                        self._controller.coordinator.async_update_listeners()
+
+                self._ssl_context_cache.clear()
+                await self._close_connection()
+                await asyncio.sleep(10.0)
+                # We reset the exponential reconnect delay to 10s if we drop off the network mid-backoff
+                self._reconnect_delay = 10.0 
+                return False
+
+            # If the handshake fails with a connection error, it returns False.
+            if not handshake_success:
+                # 2. Network UP but Port 2878 closed/crashing.
+                _LOGGER.debug("%s Handshake returned False (or skipped). Proceeding to backoff logic.", self.log_prefix)
+                self._reconnect_retries += 1
+                
+                # Create a repair issue if the device is persistently offline
+                if self._reconnect_retries == 3 and self._controller and getattr(self._controller, 'hass', None):
+                    try:
+                        async_create_issue(
+                            self._controller.hass,
+                            "climate_ip",
+                            f"connection_failed_{self._cfg.host}",
+                            is_fixable=False,
+                            severity=IssueSeverity.WARNING,
+                            translation_key="connection_failed",
+                            translation_placeholders={
+                                "host": self._cfg.host,
+                                "name": getattr(self._cfg, 'name', None) or self._cfg.host
+                            }
+                        )
+                    except Exception as e:
+                        _LOGGER.debug("%s Failed to create repair issue: %s", self.log_prefix, e)
+
+                # If we've failed 2 times on the port, force unavailability in HA
+                if self._reconnect_retries == 2:
+                    _LOGGER.error("%s AC Service is persistently offline. Forcing frontend unavailability.", self.log_prefix)
+                    if self._controller and getattr(self._controller, 'coordinator', None):
+                        self._controller.coordinator.last_update_success = False
+                        self._controller.coordinator.async_update_listeners()
+
+                _LOGGER.warning("%s Port connection failed. Backing off for %s seconds...", self.log_prefix, self._reconnect_delay)
                 self._ssl_context_cache.clear() # Force fresh SSL context on retry
                 await self._close_connection()
                 await asyncio.sleep(self._reconnect_delay)
                 self._reconnect_delay = min(self._reconnect_delay * RECONNECT_FACTOR, MAX_RECONNECT_DELAY)
                 return False
+                
         except (CannotConnect, AuthError) as e:
+            # 3. Network UP but an exception occurred during connection logic
             self._reconnect_retries += 1
+
+            # Create a repair issue if the device is persistently offline
+            if self._reconnect_retries == 3 and self._controller and getattr(self._controller, 'hass', None):
+                try:
+                    async_create_issue(
+                        self._controller.hass,
+                        "climate_ip",
+                        f"connection_failed_{self._cfg.host}",
+                        is_fixable=False,
+                        severity=IssueSeverity.WARNING,
+                        translation_key="connection_failed",
+                        translation_placeholders={
+                            "host": self._cfg.host,
+                            "name": getattr(self._cfg, 'name', None) or self._cfg.host
+                        }
+                    )
+                except Exception as ex:
+                    _LOGGER.debug("%s Failed to create repair issue: %s", self.log_prefix, ex)
+
             # If reconnection fails, fail any pending command
             if self._pending_future and not self._pending_future.done():
                 self._pending_future.set_exception(CannotConnect(f"Connection lost and reconnect failed: {e}"))
                 self._pending_future = None
-            _LOGGER.warning("%s Connection failed. Retrying in %s seconds...", self.log_prefix, self._reconnect_delay)
+                
+            _LOGGER.warning("%s Port connection error. Backing off for %s seconds...", self.log_prefix, self._reconnect_delay)
             self._ssl_context_cache.clear() # Force fresh SSL context on retry
             await self._close_connection()
             await asyncio.sleep(self._reconnect_delay)
@@ -842,6 +935,14 @@ class ConnectionSamsung2878(Connection):
 
     async def async_execute(self, method, url, data, headers, device_state=None, _is_probe=False, _is_poll=False) -> Tuple[Optional[str], Optional[Dict[str, str]]]:
         """Executes an asynchronous command (raw XML for 2878)."""
+        # Fast-fail if the connection is known to be offline and in retry backoff.
+        if not self._is_ready.is_set() and self._reconnect_retries > 0:
+            _LOGGER.debug("%s Connection is in retry backoff. Fast-failing command execution.", self.log_prefix)
+            if self._reconnect_retries >= 2:
+                raise CannotConnect("Connection is persistently offline")
+            else:
+                raise CannotConnect("Connection is temporarily offline")
+
         # Wait for the connection to be ready before proceeding.
         try:
             await asyncio.wait_for(self._is_ready.wait(), timeout=COMMAND_TIMEOUT)

--- a/custom_components/climate_ip/samsung_2878.yaml
+++ b/custom_components/climate_ip/samsung_2878.yaml
@@ -27,7 +27,7 @@ device:
         'off': { value: 'Off' }
         'on': { value: 'On' }
       status_template: '{{ device_state.AC_ADD_BEEP }}'
-      connection_template: '<Request Type="DeviceControl"><Control CommandID="AC_ADD_BEEP" DUID="{{duid}}"><Attr ID="AC_ADD_SPI" Value="{{value}}" /></Control></Request>'
+      connection_template: '<Request Type="DeviceControl"><Control CommandID="AC_ADD_BEEP" DUID="{{duid}}"><Attr ID="AC_ADD_BEEP" Value="{{value}}" /></Control></Request>'
       validation_template: '{% if "AC_ADD_BEEP" in device_state %}valid{% endif %}'
     auto_clean:
       type: switch

--- a/custom_components/climate_ip/token_acquirer.py
+++ b/custom_components/climate_ip/token_acquirer.py
@@ -92,40 +92,19 @@ class SamsungTokenAcquirer:
 
             try:
                 _LOGGER.debug("Attempting connection with Strategy: '%s', Cipher: '%s', Verify: %s", strategy_name, cipher_name, verify_mode)
-                protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
-                ssl_context = ssl.SSLContext(protocol)
-                ssl_context.set_ciphers(ciphers)
-                ssl_context.check_hostname = False
-                ssl_context.verify_mode = verify_mode
+                from .helpers import async_create_samsung_ssl_context
                 
-                if hasattr(ssl, 'TLSVersion'):
-                    if hasattr(ssl.TLSVersion, 'TLSv1_2'):
-                        try:
-                            ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
-                        except Exception as e:
-                            _LOGGER.debug("Could not set TLS max version: %s", e)
-                    if hasattr(ssl.TLSVersion, 'TLSv1'):
-                        try:
-                            ssl_context.minimum_version = ssl.TLSVersion.TLSv1
-                        except Exception:
-                            pass
+                try:
+                    ssl_context = await async_create_samsung_ssl_context(
+                        cert_path=cert_path,
+                        ciphers=ciphers,
+                        verify_mode=verify_mode
+                    )
+                except (ssl.SSLError, FileNotFoundError) as e:
+                    _LOGGER.error("Failed to load certificate '%s': %s", cert_path, e)
+                    raise CertNotFound(f"Failed to load certificate file: {e}") from e
 
-                if cert_path:
-                    _LOGGER.debug("Loading certificate: %s", os.path.basename(cert_path))
-                    try:
-                        # Use to_thread for the blocking file I/O
-                        await asyncio.to_thread(ssl_context.load_verify_locations, cafile=cert_path)
-                        await asyncio.to_thread(ssl_context.load_cert_chain, cert_path)
-                    except (ssl.SSLError, FileNotFoundError) as e:
-                        _LOGGER.error("Failed to load certificate '%s': %s", cert_path, e)
-                        raise CertNotFound(f"Failed to load certificate file: {e}") from e
-
-                # Log the configured TLS limits
-                if not logged_ssl_config:
-                    max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
-                    min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
-                    _LOGGER.debug("[SamsungTokenAcquirer] SSLContext configured. Min: %s, Max: %s", str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
-                    logged_ssl_config = True
+                logged_ssl_config = True
 
                 conn_future = asyncio.open_connection(self._ip_address, 2878, ssl=ssl_context)
                 self._reader, self._writer = await asyncio.wait_for(conn_future, timeout=15)

--- a/custom_components/climate_ip/token_acquirer_8888.py
+++ b/custom_components/climate_ip/token_acquirer_8888.py
@@ -151,33 +151,11 @@ class SamsungTokenAcquirer8888:
     async def _start_listener_server(self) -> bool:
         """Starts the custom TCP listener server."""
         try:
-            # Setup SSL for the server
-            protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
-            ssl_context = ssl.SSLContext(protocol)
-            if hasattr(ssl, 'TLSVersion'):
-                if hasattr(ssl.TLSVersion, 'TLSv1'):
-                    try:
-                        ssl_context.minimum_version = ssl.TLSVersion.TLSv1
-                    except Exception:
-                        pass
-                if hasattr(ssl.TLSVersion, 'TLSv1_2'):
-                    try:
-                        ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
-                    except Exception as e:
-                        _LOGGER.debug("Could not set TLS max version: %s", e)
-            try:
-                ssl_context.set_ciphers('HIGH:!aNULL:!MD5:@SECLEVEL=0')
-            except Exception as e:
-                _LOGGER.warning("Failed to set ciphers with SECLEVEL=0: %s", e)
-
-            await self._hass.async_add_executor_job(
-                ssl_context.load_cert_chain, self._cert_path
+            from .helpers import async_create_samsung_ssl_context
+            ssl_context = await async_create_samsung_ssl_context(
+                cert_path=self._cert_path,
+                ciphers='HIGH:!aNULL:!MD5:@SECLEVEL=0'
             )
-            
-            # Log the configured TLS limits
-            max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
-            min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
-            _LOGGER.debug("[SamsungTokenAcquirer8888 Server] SSLContext configured. Min: %s, Max: %s", str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
             
             # Start the server
             self._server = await asyncio.start_server(
@@ -204,31 +182,12 @@ class SamsungTokenAcquirer8888:
         _LOGGER.info("Requesting token from AC at %s:%s", self._ac_ip, self._ac_port)
 
         # Setup Client SSL Context
-        protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1))
-        ssl_context = ssl.SSLContext(protocol)
-        if hasattr(ssl, 'TLSVersion'):
-            if hasattr(ssl.TLSVersion, 'TLSv1'):
-                try:
-                    ssl_context.minimum_version = ssl.TLSVersion.TLSv1
-                except Exception:
-                    pass
-            if hasattr(ssl.TLSVersion, 'TLSv1_2'):
-                try:
-                    ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
-                except Exception as e:
-                    _LOGGER.debug("Could not set TLS max version: %s", e)
-        ssl_context.set_ciphers('HIGH:!aNULL:!MD5:@SECLEVEL=0')
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-        
-        await self._hass.async_add_executor_job(
-            ssl_context.load_cert_chain, self._cert_path
+        from .helpers import async_create_samsung_ssl_context
+        ssl_context = await async_create_samsung_ssl_context(
+            cert_path=self._cert_path,
+            ciphers='HIGH:!aNULL:!MD5:@SECLEVEL=0',
+            verify_mode=ssl.CERT_NONE
         )
-
-        # Log the configured TLS limits
-        max_ver = getattr(ssl_context, 'maximum_version', 'Unknown')
-        min_ver = getattr(ssl_context, 'minimum_version', 'Unknown')
-        _LOGGER.debug("[SamsungTokenAcquirer8888 Client] SSLContext configured. Min: %s, Max: %s", str(min_ver).replace('TLSVersion.', ''), str(max_ver).replace('TLSVersion.', ''))
 
         try:
             async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
### Added
- **Ping Gate (Port 2878)**: Implemented ICMP connectivity pre-check before every TCP reconnection attempt for port 2878 devices. If the device is unreachable at network level, the integration skips the TCP socket entirely to protect fragile AC firmware from hanging on connection attempts. Uses a fixed 10-second retry interval when the device is offline, and an adaptive exponential backoff (5→10→20→40→…s) once the ping succeeds but the port connection fails.
- **Ping Gate (Port 8888)**: Extended the ICMP pre-check to port 8888 devices via the `DataUpdateCoordinator` polling cycle. If the device is unreachable, the polling cycle returns immediately without opening a TCP/SSL socket, reducing unnecessary network traffic and protecting older AC units.
- **HA Repair Issues (All Devices)**: After 3 consecutive connection failures (via ping or socket), a Home Assistant Repair Issue (`connection_failed`) is automatically created in the frontend, identifying the device by name and IP. The issue is automatically resolved when the device reconnects successfully.
- **Shared Ping Utility**: Extracted `async_check_network_reachability` to `helpers.py` as a shared async helper used by all connection engines. Supports Linux/macOS (`ping -c 1 -W 2`) and Windows (`ping -n 1 -w 2000`).

### Changed
- **Code Duplication**: Centralized the `check_execute_condition` logic into the base `Connection` class to resolve code duplication across `connection_request.py`, `connection_aiohttp.py`, and `connection_raw.py`.
- **SSL Context**: Consolidated SSL context creation by moving `async_create_samsung_ssl_context` to `helpers.py`. All connection engines now use this shared helper, ensuring consistent TLS and cipher parameter sets.
- **Log Refinement**: Removed redundant and noisy `[DEBUG_PRINT]`, `[DEBUG coordinator]`, and `Shared SSLContext configured` statements during application startup for a cleaner standard output.
- **Log Verbosity (Offline Devices)**: Downgraded transient and persistent connection failure log messages in `coordinator.py` from `WARNING`/`ERROR` to `DEBUG` to prevent log spam when a device is intentionally offline or powered off.

### Fixed
- **Parameter Resolution**: Removed a fragile "template hack" in connection instantiation (`create_updated`) that forced static parameters into mock Jinja templates. Static parameters are now stored natively and resolved accurately via a new `_resolve_async_params` helper in `properties.py`.
- **TLS Version Logging**: Fixed an issue where the `SSLContext configured...` logs printed raw OpenSSL integer codes (e.g., `769`, `771`) instead of readable names like `TLSv1` or `TLSv1_2` in certain Python environments.