### PR TITLE
Fix MIM-H03 multi-unit support, TLS/HTTP compatibility, and mode-switch endpoint

### DIFF
--- a/custom_components/climate_ip/climate.py
+++ b/custom_components/climate_ip/climate.py
@@ -155,14 +155,13 @@ class ClimateIP(CoordinatorEntity[SamsungClimateCoordinator], ClimateEntity):
         if device_info:
             # This is a sub-device (e.g., an indoor unit of a MIM-H03).
             # Its unique_id is the UUID provided for it.
-            self._name = user_defined_name or device_info.get("name", f"Indoor Unit {device_info.get('id')}")
+            self._name = device_info.get("name") or user_defined_name or f"Indoor Unit {device_info.get("id")}"
             self._attr_unique_id = device_info.get("uuid") or f"{self._main_unique_id}_{device_info.get('id')}"
             
-            # This establishes the correct parent-child relationship in the device registry.
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self._attr_unique_id)},
                 name=self._name,
-                via_device=(DOMAIN, self._main_unique_id),  # Link to the parent device
+                manufacturer="Samsung",
             )
         else:
             # This is a single-device entry (e.g., a standalone AC).

--- a/custom_components/climate_ip/config_flow.py
+++ b/custom_components/climate_ip/config_flow.py
@@ -111,8 +111,12 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input[CONF_MAC] = mac_address.replace(":", "").upper()
             # --- END OF FIX ---
 
-        # Use the sanitized MAC or IP as unique_id. MAC is preferred.
-        unique_id = user_input.get(CONF_MAC) or user_input.get(CONF_IP_ADDRESS)
+        # Use MAC or IP + device_id as unique_id.
+        # Including device_id supports multiple indoor units (device_ids) per controller (same IP).
+        # This is required for multi-split systems like Samsung MIM-H03.
+        base_id = user_input.get(CONF_MAC) or user_input.get(CONF_IP_ADDRESS)
+        device_id = user_input.get(CONF_DEVICE_ID, )
+        unique_id = f"{base_id}_{device_id}" if device_id else base_id
         # --- END: Sanitize MAC and set unique_id ---
 
         await self.async_set_unique_id(unique_id)
@@ -262,6 +266,21 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=schema)
 
+    def _get_poll_interval_default(self) -> str:
+        """Return poll interval as H:MM:SS string, handling both int and str stored values."""
+        poll = self.flow_data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
+        if isinstance(poll, str):
+            # Already a formatted string like 0:01:00, validate it can be parsed
+            try:
+                parts = poll.split(":")
+                if len(parts) == 3:
+                    seconds = int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+                    return str(datetime.timedelta(seconds=seconds))
+            except (ValueError, AttributeError):
+                pass
+            return str(datetime.timedelta(seconds=DEFAULT_POLL_INTERVAL))
+        return str(datetime.timedelta(seconds=int(poll)))
+
     def _get_base_samsung_schema(self, mac_required: bool = False, is_8888: bool = False) -> vol.Schema:
         """Helper to dynamically generate the shared base schema for Samsung devices."""
         raw_mac = self.flow_data.get(CONF_MAC, "")
@@ -281,7 +300,7 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional(CONF_TOKEN, default=self.flow_data.get(CONF_TOKEN, "")): str,
             vol.Optional(CONF_CERT, default=self.flow_data.get(CONF_CERT, "ac14k_m.pem" if is_8888 else "")): str,
             vol.Optional(
-                CONF_POLL_INTERVAL, default=str(datetime.timedelta(seconds=self.flow_data.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)))
+                CONF_POLL_INTERVAL, default=self._get_poll_interval_default()
             ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
         })
         
@@ -363,8 +382,11 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Standardize the name to ensure consistency
             if not self.flow_data.get(CONF_NAME):
-                mac = self.flow_data[CONF_MAC]
+                mac = self.flow_data.get(CONF_MAC) or self.flow_data.get(CONF_IP_ADDRESS, "unknown")
                 self.flow_data[CONF_NAME] = f"Samsung AC {mac}"
+
+            if not self.flow_data.get(CONF_NAME):
+                self.flow_data[CONF_NAME] = f'Samsung MIM-H03 {self.flow_data.get(CONF_IP_ADDRESS, unknown)}'
 
             if self.flow_data.get(CONF_TOKEN):
                 return await self.async_step_test_connection()
@@ -402,12 +424,19 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             
             error_reason = await self._async_resolve_mac_and_set_unique_id(ip_address, mac_address)
             if error_reason:
-                errors["base"] = error_reason
-                return self.async_show_form(
-                    step_id="samsung_8888",
-                    data_schema=self._get_samsung_8888_schema(mac_required=(error_reason == "mac_resolve_failed")),
-                    errors=errors,
-                )
+                if error_reason == "mac_resolve_failed":
+                    # MAC not resolvable (cross-subnet device). Fall back to IP as unique_id base.
+                    # This is fine since we include device_id in the unique_id anyway.
+                    _LOGGER.info("MAC resolve failed for %s, using IP as unique_id base.", ip_address)
+                    await self.async_set_unique_id(ip_address)
+                    self._abort_if_unique_id_configured()
+                else:
+                    errors["base"] = error_reason
+                    return self.async_show_form(
+                        step_id="samsung_8888",
+                        data_schema=self._get_samsung_8888_schema(mac_required=False),
+                        errors=errors,
+                    )
 
             # Validate polling interval
             if CONF_POLL_INTERVAL in user_input:
@@ -920,7 +949,7 @@ class ClimateIpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         device_type = self.flow_data.get(CONF_DEVICE_TYPE)
 
         if device_type == DEVICE_TYPE_MIM_H03:
-            step_id = "mim_h03"
+            step_id = "samsung_8888"  # MIM-H03 uses same handler as samsung_8888
             schema = self._get_samsung_8888_schema(mac_required=False)
         elif device_type == DEVICE_TYPE_SAMSUNG_8888:
             step_id = "samsung_8888"

--- a/custom_components/climate_ip/connection_request.py
+++ b/custom_components/climate_ip/connection_request.py
@@ -43,6 +43,13 @@ class SamsungHTTPAdapter(HTTPAdapter):
             verify_mode=ssl.CERT_NONE
         )
 
+        # Samsung MIM-H03 does not support SNI - disable it to prevent TLS handshake failure
+        _orig_wrap = ssl_context.wrap_socket
+        def _wrap_no_sni(sock, *a, **kw):
+            kw.pop("server_hostname", None)
+            return _orig_wrap(sock, *a, **kw)
+        ssl_context.wrap_socket = _wrap_no_sni
+
         pool_kwargs["ssl_context"] = ssl_context
         
         # --- START OF FIX: Limit Pool Concurrency ---
@@ -100,6 +107,12 @@ class ConnectionRequestBase(Connection):
             self._session = requests.sessions.Session()
             self._session.verify = False 
             self._session.mount("https://", SamsungHTTPAdapter())
+            # Samsung LibSHP/1.0 cannot handle compressed responses
+            self._session.headers.update({
+                'Accept-Encoding': 'identity',
+                'User-Agent': None,
+                'Accept': None,
+            })
         
         # --- START OF FIX: Read keep_alive setting ---
         self._keep_alive = hass_config.get("keep_alive", True) if hass_config else True
@@ -556,6 +569,12 @@ class ConnectionRequestBase(Connection):
             new_session = requests.sessions.Session()
             new_session.verify = False 
             new_session.mount("https://", SamsungHTTPAdapter())
+            # Samsung LibSHP/1.0 cannot handle compressed responses
+            new_session.headers.update({
+                'Accept-Encoding': 'identity',
+                'User-Agent': None,
+                'Accept': None,
+            })
              
             # Reset adaptive flags to give connection reuse a chance in the new cycle
             self._force_close_connection = False

--- a/custom_components/climate_ip/controller_yaml_state.py
+++ b/custom_components/climate_ip/controller_yaml_state.py
@@ -379,8 +379,11 @@ class YamlControllerStateMixin:
                         if device_to_discover:
                             discovered_id = get_value_by_path(device_to_discover, id_map.get("id", []))
                             if discovered_id is not None:
-                                self._device_id = str(discovered_id)
-                            _LOGGER.info("%s Discovered device with id=%s", self.log_prefix, self._device_id)
+                                # Only overwrite device_id if not already configured (indoor unit controllers
+                                # are created with CONF_DEVICE_ID="032001000" etc. and must not be changed).
+                                if not self._config.get(CONF_DEVICE_ID):
+                                    self._device_id = str(discovered_id)
+                            _LOGGER.info("%s Discovered coordinator id=%s, keeping device_id=%s", self.log_prefix, discovered_id, self._device_id)
 
                 # Now that _device_id is potentially assigned, finish initialization
                 await self._finish_initialization()
@@ -432,14 +435,27 @@ class YamlControllerStateMixin:
                 if devices_list:
                     _LOGGER.debug("%s Found %d devices in state. Selecting correct one.", self.log_prefix, len(devices_list))
                     
-                    # Simplified logic: Take the first valid device
-                    found_device = devices_list[0] if devices_list[0] else None
-                    # Future improvement: select the device based on self._device_id
+                    # Select the indoor unit matching CONF_DEVICE_ID (e.g. "032001000").
+                    # Discovery may overwrite self._device_id to "0" (coordinator),
+                    # so we use CONF_DEVICE_ID which holds the original indoor unit id.
+                    configured_device_id = str(self._config.get(CONF_DEVICE_ID, ""))
+                    id_keys = id_map.get("id", [])
+                    found_device = None
+                    if configured_device_id:
+                        found_device = next(
+                            (d for d in devices_list
+                             if d and str(get_value_by_path(d, id_keys)) == configured_device_id),
+                            None
+                        )
+                    if not found_device:
+                        found_device = next((d for d in devices_list if d and "Mode" in d), None)
+                    if not found_device and devices_list:
+                        found_device = devices_list[0]
                     if found_device:
-                        _LOGGER.debug("%s Success. 'device_to_process' is now the sub-device", self.log_prefix)
+                        _LOGGER.debug("%s Selected sub-device id=%s", self.log_prefix, get_value_by_path(found_device, id_keys))
                         device_to_process = found_device
                     else:
-                        _LOGGER.warning("%s 'devices_list' exists but the first element is empty or null", self.log_prefix)
+                        _LOGGER.warning("%s No valid sub-device found in devices_list", self.log_prefix)
                 else:
                     _LOGGER.warning("%s 'identifiers' exists but the path '%s' did not return a list", self.log_prefix, id_map.get("path_to_devices", []))
             else:

--- a/custom_components/climate_ip/mim-h03_heatpump.yaml
+++ b/custom_components/climate_ip/mim-h03_heatpump.yaml
@@ -34,15 +34,14 @@ device:
     hvac: # hvac_mode
       type: modes
       connection:
-        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/' }
+        params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/mode' }
       values:
-        cool: { value : 'Opmode_Cool', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Cool"] } } } } } 
-        heat: { value : 'Opmode_Heat', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Heat"] } } } } } 
-        'off': { value: 'Off', connection: { params: { json: { "Operation": { "power" : "Off" } } } } } 
-        auto: { value : 'Opmode_Auto', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Auto"] } } } } } 
-        heat_cool: { value : 'Opmode_Auto', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Auto"] } } } } } 
-        fan_only: { value : 'Opmode_Fan', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Fan"] } } } } } 
-        dry: { value : 'Opmode_Dry', connection: { params: { json: { "Operation": { "power" : "On" }, "Mode": { "modes": ["Opmode_Dry"] } } } } } 
+        cool: { value : 'Opmode_Cool', connection: { params: { json: { "Mode": { "modes": ["Opmode_Cool"] } } }, connection: { params: { json: { "Operation": { "power" : "On" } }, url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' }, condition_template: "{% if device_state.Operation.power == 'Off' -%}1{%- else -%}0{%- endif %}" } } } 
+        heat: { value : 'Opmode_Heat', connection: { params: { json: { "Mode": { "modes": ["Opmode_Heat"] } } }, connection: { params: { json: { "Operation": { "power" : "On" } }, url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' }, condition_template: "{% if device_state.Operation.power == 'Off' -%}1{%- else -%}0{%- endif %}" } } } 
+        'off': { value: 'Off', connection: { params: { json: { "Operation": { "power" : "Off" } }, url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' } } } 
+        auto: { value : 'Opmode_Auto', connection: { params: { json: { "Mode": { "modes": ["Opmode_Auto"] } } }, connection: { params: { json: { "Operation": { "power" : "On" } }, url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' }, condition_template: "{% if device_state.Operation.power == 'Off' -%}1{%- else -%}0{%- endif %}" } } }  
+        fan_only: { value : 'Opmode_Fan', connection: { params: { json: { "Mode": { "modes": ["Opmode_Fan"] } } }, connection: { params: { json: { "Operation": { "power" : "On" } }, url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' }, condition_template: "{% if device_state.Operation.power == 'Off' -%}1{%- else -%}0{%- endif %}" } } } 
+        dry: { value : 'Opmode_Dry', connection: { params: { json: { "Mode": { "modes": ["Opmode_Dry"] } } }, connection: { params: { json: { "Operation": { "power" : "On" } }, url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' }, condition_template: "{% if device_state.Operation.power == 'Off' -%}1{%- else -%}0{%- endif %}" } } } 
       # NOTA: Los status_template ahora deben apuntar a la raíz del objeto del dispositivo seleccionado,
       # ya que el controlador se encargará de pasar el objeto correcto.
       # La lógica original es correcta si el controlador pasa el sub-objeto del dispositivo.
@@ -52,7 +51,7 @@ device:
       connection:
         params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' }
       values:
-        'off': { value: 'Off', connection: { params: { json: { "Operation": { "power" : "Off" } } } } }
+        'off': { value: 'Off', connection: { params: { json: { "Operation": { "power" : "Off" } }, url: 'https://__CLIMATE_IP_HOST__:8888/devices/__DEVICE_ID__/operation' } } }
         'on': { value: 'On', connection: { params: { json: { "Operation": { "power" : "On" } } } } }
       status_template: '{{ device_state.Operation.power }}'
     beep:


### PR DESCRIPTION
## Summary

A handful of fixes for the Samsung MIM-H03 multi-split controller, found and fixed while running two indoor units (living room + bedroom) behind a single MIM-H03 hub on v9.2.1.

- **TLS/HTTP compatibility**: the MIM-H03's embedded HTTPS server doesn't support SNI and its LibSHP/1.0 stack chokes on compressed responses. Disabled SNI on the wrapped socket and force `Accept-Encoding: identity`.
- **HVAC mode endpoint**: the firmware rejects a single combined PUT with both `Mode` and `Operation.power`. Split into a `.../mode` call plus a conditional follow-up `.../operation` call to turn the unit on if it was off.
- **Multi-unit support**: `config_flow` previously used MAC/IP alone as `unique_id`, which collides when a MIM-H03 exposes more than one indoor unit on the same IP/MAC. `unique_id` now includes `device_id`. Device discovery in `controller_yaml_state` previously always picked `devices_list[0]` (left as a `# Future improvement` TODO in the code) instead of the configured `device_id` — implemented that selection. Also added a graceful fallback to IP-based `unique_id` when MAC resolution fails (useful when the MIM-H03 sits on a different subnet), and routed the MIM-H03 flow through the existing `samsung_8888` step instead of a separate one.
- **Naming/device registry**: prefer the per-unit `device_info` name over `user_defined_name` for sub-devices, and drop the `via_device` parent link so each indoor unit registers as its own device rather than nesting under the hub (this was contributing to confusing/duplicated entity IDs when the device is also assigned to an area of the same name).

Each change is its own commit for easier review. Tested on a live MIM-H03 with 2 indoor units for several days.

## Test plan
- [x] Two indoor units configured on the same MIM-H03 controller, verified distinct `unique_id`/entities for each
- [x] Mode changes (cool/heat/dry/fan_only/auto/off) verified against physical units
- [x] Confirmed prior TLS handshake resets / connection errors no longer occur over a multi-day run
