### PR TITLE
feat: 3-tier dynamic ICMP detection and hybrid network diagnostics (v10.0.1b7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [10.0.1b7] - 2026-09-10
+
+### Improvements & Network Resilience
+- **3-Tier Dynamic ICMP Privilege Detection**: Added dynamic probe (`_can_use_icmp_privileged`) to automatically use raw ICMP sockets (`privileged=True`) in Home Assistant OS and container environments with root/`CAP_NET_RAW`, gracefully falling back to datagram sockets (`privileged=False`) for non-root users, and bypassing to direct TCP connection if OS policies restrict all ICMP sockets.
+- **Hybrid Network Diagnostics & Telemetry**: Integrated hybrid ICMP diagnostics combining runtime polling telemetry (`last_runtime_check` capturing status, RTT, and socket tier from `YamlStatePoller` and `ConnectionSamsung2878`) with an on-demand live probe (`active_probe` with a responsive 1.0s timeout) when generating Home Assistant diagnostics bundles in `diagnostics.py`.
+- **Global Network Diagnostics Registry**: Implemented `_LAST_NETWORK_DIAGNOSTICS` cache and `get_last_network_diagnostic()` in `helpers.py` ensuring telemetry availability across connection types while strictly complying with privacy redaction standards.
+
+### Quality Assurance & Test Suite Hardening
+- **Comprehensive Mutation Resistance**: Added targeted test suites (`test_config_flow__basics.py`, `test_token_acquirer_yaml__stream.py`, and `test_connection_intesisbox__yaml.py`) expanding test coverage to 1,533 passing tests with zero regressions.
+- **Network & Diagnostics Coverage**: Full coverage for 3-tier ICMP detection, string slicing boundaries, unbracketed IPv6 addresses, and active/passive diagnostic payloads in `test_helpers__advanced.py` and `test_diagnostics.py`.
+
 ## [10.0.1b6] - 2026-09-10
 
 ### Fixes & Hardware Robustness
@@ -18,7 +29,7 @@
 - **Multi-Language Support**: Complete configuration flow translations for English, Spanish, German, and French (`strings.json`, `en.json`, `es.json`, `de.json`, `fr.json`).
 
 ### Testing & Quality Assurance
-- **Comprehensive Test Suite**: Added `test_intesisbox_yaml.py` covering YAML validation, connection lifecycle, sequential ACK verification, live emulator interaction, and config flow discovery.
+- **Comprehensive Test Suite**: Added `test_connection_intesisbox__yaml.py` covering YAML validation, connection lifecycle, sequential ACK verification, live emulator interaction, and config flow discovery.
 - **Regression Baseline**: Maintained 100% test pass rate across 1,467 unit tests and zero lint errors with Ruff.
 
 ## [10.0.1b4] - 2026-09-07

--- a/config_flow.py
+++ b/config_flow.py
@@ -423,7 +423,7 @@ class ClimateIpConfigFlow(
                     DEVICE_TYPE_INTESISBOX
                 ]
                 self.flow_data[CONF_TOKEN] = str(
-                    self.flow_data.get(CONF_MAC, mac_val or "intesisbox")
+                    self.flow_data.get(CONF_MAC, mac_val or "intesisbox")  # pragma: no mutate  # Equivalent: mac_val == flow_data[CONF_MAC] when key exists
                 )
                 return self.async_create_entry(
                     title=f"IntesisBox ({ip_addr})",

--- a/connection_intesisbox.py
+++ b/connection_intesisbox.py
@@ -288,7 +288,9 @@ class ConnectionIntesisBox(Connection):
 
     async def _reader_loop(self) -> None:
         """Continuously read lines from IntesisBox socket and parse updates."""
-        self.logger.debug("%s Started background TCP reader loop", self.log_prefix)
+        self.logger.debug(
+            "%s Started background TCP reader loop", self.log_prefix
+        )  # pragma: no mutate
         try:
             while not self._closing and self._reader:
                 line_bytes = await self._reader.readline()
@@ -296,7 +298,7 @@ class ConnectionIntesisBox(Connection):
                     # Connection closed by remote
                     self.logger.warning(
                         "%s Remote closed TCP connection (EOF)", self.log_prefix
-                    )
+                    )  # pragma: no mutate
                     break
 
                 raw_line = line_bytes.decode("ascii", errors="ignore").strip()
@@ -306,15 +308,17 @@ class ConnectionIntesisBox(Connection):
         except asyncio.CancelledError:
             self.logger.debug(
                 "%s Reader task cancelled gracefully", self.log_prefix
-            )
+            )  # pragma: no mutate
         except Exception as err:
             if not self._closing:
                 self.logger.error(
                     "%s Unexpected error in reader loop: %s", self.log_prefix, err
-                )
+                )  # pragma: no mutate
         finally:
             self._is_connected = False
-            self.logger.debug("%s Exited background TCP reader loop", self.log_prefix)
+            self.logger.debug(
+                "%s Exited background TCP reader loop", self.log_prefix
+            )  # pragma: no mutate
 
     def _process_incoming_line(self, line: str) -> None:
         """Parse an individual protocol line and update state or futures."""
@@ -430,7 +434,7 @@ class ConnectionIntesisBox(Connection):
         ]
         active_hist = self._node_history[uid]
 
-        if len(active_hist) >= threshold + 1:
+        if len(active_hist) >= threshold + 1:  # pragma: no mutate  # Guard: len >= threshold + 1 is required for alternations >= threshold
             distinct_values = set(v for _, v in active_hist)
             if len(distinct_values) == 2:
                 bad_val = None
@@ -446,7 +450,7 @@ class ConnectionIntesisBox(Connection):
                     bad_val = active_hist[-1][1]
                     other_val = next(v for v in distinct_values if v != bad_val)
 
-                if bad_val and other_val:
+                if bad_val and other_val:  # pragma: no mutate  # Equivalent: both values guaranteed non-empty from distinct_values
                     alternations = 0
                     for i in range(1, len(active_hist)):
                         if active_hist[i][1] != active_hist[i - 1][1]:
@@ -491,7 +495,9 @@ class ConnectionIntesisBox(Connection):
             new_limits_str = None
 
             if bad_val in prune_values and prune_template:
-                current_raw = self._limits.get(uid, "")
+                current_raw = self._limits.get(
+                    uid, ""
+                )  # pragma: no mutate  # Equivalent: empty string vs None in bool check
                 if current_raw:
                     cleaned = current_raw.strip("[]")
                     items = [

--- a/controller_yaml.py
+++ b/controller_yaml.py
@@ -651,11 +651,14 @@ class YamlController(ClimateController):
     @property
     def connection_diagnostics(self) -> dict[str, Any]:
         """Return standardized connection diagnostic dictionary from the underlying connection."""
+        diag: dict[str, Any] = {}
         if self.connection is not None and hasattr(self.connection, "get_diagnostics"):
-            diag = self.connection.get_diagnostics()
-            if isinstance(diag, dict):
-                return dict(diag)
-        return {}
+            conn_diag = self.connection.get_diagnostics()
+            if isinstance(conn_diag, dict):
+                diag = dict(conn_diag)
+        if hasattr(self, "poller") and getattr(self.poller, "last_icmp_diagnostic", None):
+            diag["network_reachability"] = self.poller.last_icmp_diagnostic
+        return diag
 
     @property
     def pure_device_state(self) -> dict[str, Any]:

--- a/controller_yaml_polling.py
+++ b/controller_yaml_polling.py
@@ -35,7 +35,11 @@ from .const import (
     DOMAIN,
 )
 from .exceptions import AuthError, CannotConnect, InvalidHeaderError
-from .helpers import async_check_network_reachability, get_value_by_path
+from .helpers import (
+    async_check_network_reachability,
+    get_last_network_diagnostic,
+    get_value_by_path,
+)
 from .properties import render_template
 from .state import ClimateIPDeviceState
 
@@ -110,6 +114,7 @@ class YamlStatePoller:
         self._cached_device_state: dict[str, Any] | None = None
         self._last_state_fetch_time: float = 0.0
         self._last_device_state: dict[str, Any] | None = None
+        self._last_icmp_diagnostic: dict[str, Any] | None = None
         self._consecutive_connection_errors: int = 0
 
         self._pure_network_state: dict[str, Any] | None = None
@@ -128,6 +133,11 @@ class YamlStatePoller:
         """Clear specific pending updates (anti-flicker locks) instantly."""
         for key in keys:
             self._pending_updates.pop(key, None)
+
+    @property
+    def last_icmp_diagnostic(self) -> dict[str, Any] | None:
+        """Return the last ICMP network diagnostic result."""
+        return self._last_icmp_diagnostic
 
     def _clear_state_cache(self) -> None:
         """Clear internal state cache buffer to prevent stale data (anti-ghosting)."""
@@ -331,6 +341,13 @@ class YamlStatePoller:
             network_reachable = await async_check_network_reachability(
                 self.controller.ip_address, self.controller.log_prefix
             )
+            self._last_icmp_diagnostic = get_last_network_diagnostic(
+                self.controller.ip_address
+            ) or {
+                "is_reachable": network_reachable,
+                "status": "alive" if network_reachable else "unreachable_timeout",
+                "timestamp": dt_util.utcnow().isoformat(),
+            }
         except Exception as diag_err:
             _LOGGER.debug(
                 "%s ICMP check failed: %s", self.controller.log_prefix, diag_err

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -11,6 +11,11 @@ from homeassistant.const import CONF_MAC
 from homeassistant.core import HomeAssistant
 
 from .coordinator import SamsungClimateCoordinator
+from .helpers import (
+    _can_use_icmp_privileged,
+    async_get_network_diagnostics,
+    get_last_network_diagnostic,
+)
 
 if TYPE_CHECKING:
     from . import ClimateIPConfigEntry
@@ -279,6 +284,67 @@ async def async_get_config_entry_diagnostics(
             total_skipped
         )
         diagnostics_data["bootstrapping"]["active_entities"] = total_entities
+
+    # Determine target host for active probe and runtime telemetry lookup
+    target_host: str | None = None
+    if isinstance(entry.data, dict):
+        target_host = entry.data.get("host") or entry.data.get("ip_address")
+    if not target_host and isinstance(entry.options, dict):
+        target_host = entry.options.get("host") or entry.options.get("ip_address")
+    if not target_host and isinstance(entry_data, SamsungClimateCoordinator):
+        ctrl = entry_data.controller
+        target_host = (
+            getattr(ctrl, "ip_address", None)
+            or getattr(ctrl, "host", None)
+            or getattr(getattr(ctrl, "_cfg", None), "host", None)
+        )
+    elif not target_host and isinstance(entry_data, dict):
+        for coordinator in entry_data.values():
+            if isinstance(coordinator, SamsungClimateCoordinator):
+                ctrl = coordinator.controller
+                target_host = (
+                    getattr(ctrl, "ip_address", None)
+                    or getattr(ctrl, "host", None)
+                    or getattr(getattr(ctrl, "_cfg", None), "host", None)
+                )
+                if target_host:
+                    break
+
+    # Extract historical runtime ICMP telemetry
+    last_runtime_check: dict[str, Any] | None = None
+    if "connection_diagnostics" in diagnostics_data:
+        last_runtime_check = diagnostics_data["connection_diagnostics"].get(
+            "network_reachability"
+        )
+    if not last_runtime_check and "coordinators" in diagnostics_data:
+        for coord_diag in diagnostics_data["coordinators"].values():
+            conn_diag = coord_diag.get("connection_diagnostics", {})
+            if "network_reachability" in conn_diag:
+                last_runtime_check = conn_diag["network_reachability"]
+                break
+    if not last_runtime_check and target_host:
+        last_runtime_check = get_last_network_diagnostic(target_host)
+
+    # Perform on-demand live active probe with quick 1.0s timeout
+    active_probe: dict[str, Any]
+    if target_host:
+        active_probe = await async_get_network_diagnostics(
+            target_host, ping_timeout=1.0
+        )
+    else:
+        active_probe = {
+            "is_reachable": None,
+            "status": "no_host_configured",
+        }
+
+    diagnostics_data["network_diagnostics"] = {
+        "privileged_probe_support": _can_use_icmp_privileged(),
+        "last_runtime_check": last_runtime_check or {
+            "is_reachable": None,
+            "status": "not_recorded",
+        },
+        "active_probe": active_probe,
+    }
 
     # Apply Home Assistant's native async_redact_data to recursively clean
     # the entire diagnostic tree (including nested YAML dictionaries or raw responses).

--- a/helpers.py
+++ b/helpers.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 
 from homeassistant.const import EntityCategory
 from homeassistant.helpers import config_validation as cv
+from homeassistant.util import dt as dt_util
 from voluptuous.error import Invalid
 
 _LOGGER = logging.getLogger(__name__)
@@ -538,6 +539,41 @@ except ImportError:
     SocketPermissionError = _DummyIcmpError
 
 
+@functools.lru_cache(maxsize=1)
+def _can_use_icmp_privileged() -> bool:
+    """Probe whether the environment supports raw ICMP sockets (root or CAP_NET_RAW)."""
+    if not _ICMPLIB_AVAILABLE:
+        return False
+    try:
+        from icmplib import (
+            ping as icmp_ping_sync,  # pylint: disable=import-outside-toplevel
+        )
+
+        icmp_ping_sync("127.0.0.1", count=0, timeout=0, privileged=True)
+        return True
+    except Exception:
+        return False
+
+
+_LAST_NETWORK_DIAGNOSTICS: dict[str, dict[str, Any]] = {}
+
+
+def get_last_network_diagnostic(host: str | None) -> dict[str, Any] | None:
+    """Return the last recorded ICMP network diagnostic for the host."""
+    if not host or not isinstance(host, str):
+        return None
+    clean_host = host.rsplit("://")[-1].split("/")[0]  # noqa: PLC0207
+    if (
+        ":" in clean_host
+        and not clean_host.startswith("[")
+        and clean_host.count(":") == 1
+    ):
+        clean_host = clean_host.split(":")[0]
+    elif clean_host.startswith("[") and "]" in clean_host:
+        clean_host = clean_host[1 : clean_host.index("]")]  # pragma: no mutate  # Equivalent: valid IPv6 has single ']'
+    return _LAST_NETWORK_DIAGNOSTICS.get(clean_host)
+
+
 # pylint: disable=too-many-return-statements
 async def async_check_network_reachability(
     host: str, log_prefix: str = ""
@@ -565,16 +601,25 @@ async def async_check_network_reachability(
     if clean_host in ("localhost", "127.0.0.1", "::1"):
         return True
 
+    use_privileged = _can_use_icmp_privileged()
+
     try:
         host_obj = await async_ping(  # pragma: no mutate
             address=clean_host,
             count=1,
             timeout=2.0,
             interval=0.2,
-            privileged=False,  # pragma: no mutate
+            privileged=use_privileged,  # pragma: no mutate
         )  # pragma: no mutate
 
         if host_obj.is_alive:
+            _LAST_NETWORK_DIAGNOSTICS[clean_host] = {
+                "is_reachable": True,
+                "avg_rtt_ms": getattr(host_obj, "avg_rtt", None),
+                "status": "alive",
+                "privileged_mode": use_privileged,
+                "timestamp": dt_util.utcnow().isoformat(),
+            }
             return True
 
         _LOGGER.debug(  # pragma: no mutate
@@ -583,6 +628,13 @@ async def async_check_network_reachability(
             log_prefix,  # pragma: no mutate
             host,  # pragma: no mutate
         )  # pragma: no mutate
+        _LAST_NETWORK_DIAGNOSTICS[clean_host] = {
+            "is_reachable": False,
+            "avg_rtt_ms": None,
+            "status": "unreachable_timeout",
+            "privileged_mode": use_privileged,
+            "timestamp": dt_util.utcnow().isoformat(),
+        }
         return False
 
     except SocketPermissionError as perm_err:
@@ -592,11 +644,28 @@ async def async_check_network_reachability(
             log_prefix,  # pragma: no mutate
             perm_err,  # pragma: no mutate
         )  # pragma: no mutate
+        _LAST_NETWORK_DIAGNOSTICS[clean_host] = {
+            "is_reachable": True,
+            "avg_rtt_ms": None,
+            "status": "permission_bypassed",
+            "privileged_mode": use_privileged,
+            "timestamp": dt_util.utcnow().isoformat(),
+        }
         return True
     except (IcmpNameLookupError, ICMPSocketError) as err:
         _LOGGER.debug(
             "%s Network diagnostic error for %s: %s", log_prefix, host, err
         )  # pragma: no mutate
+        status_name = (
+            "dns_error" if isinstance(err, IcmpNameLookupError) else "socket_error"
+        )
+        _LAST_NETWORK_DIAGNOSTICS[clean_host] = {
+            "is_reachable": False,
+            "avg_rtt_ms": None,
+            "status": status_name,
+            "privileged_mode": use_privileged,
+            "timestamp": dt_util.utcnow().isoformat(),
+        }
         return False
     except OSError as e:
         _LOGGER.debug(  # pragma: no mutate
@@ -605,7 +674,152 @@ async def async_check_network_reachability(
             log_prefix,  # pragma: no mutate
             e,  # pragma: no mutate
         )  # pragma: no mutate
+        _LAST_NETWORK_DIAGNOSTICS[clean_host] = {
+            "is_reachable": True,
+            "avg_rtt_ms": None,
+            "status": "permission_bypassed",
+            "privileged_mode": use_privileged,
+            "timestamp": dt_util.utcnow().isoformat(),
+        }
         return True
+
+
+# pylint: disable=too-many-return-statements
+async def async_get_network_diagnostics(
+    host: str, log_prefix: str = "", ping_timeout: float = 1.0
+) -> dict[str, Any]:
+    """Execute a detailed ICMP probe returning complete telemetry for diagnostics."""
+    now_iso = dt_util.utcnow().isoformat()
+    if not host or not isinstance(host, str):
+        return {
+            "is_reachable": False,
+            "avg_rtt_ms": None,
+            "status": "missing_host",
+            "privileged_mode": False,
+            "timestamp": now_iso,
+        }
+
+    if not _ICMPLIB_AVAILABLE or async_ping is None:
+        _LOGGER.debug(
+            "%s icmplib not available, skipping ICMP reachability check.", log_prefix
+        )
+        return {
+            "is_reachable": True,
+            "avg_rtt_ms": None,
+            "status": "library_missing",
+            "privileged_mode": False,
+            "timestamp": now_iso,
+        }
+
+    clean_host = host.rsplit("://")[-1].split("/")[0]  # noqa: PLC0207
+    if (
+        ":" in clean_host
+        and not clean_host.startswith("[")
+        and clean_host.count(":") == 1
+    ):
+        clean_host = clean_host.split(":")[0]
+    elif clean_host.startswith("[") and "]" in clean_host:
+        clean_host = clean_host[1 : clean_host.index("]")]  # pragma: no mutate  # Equivalent: valid IPv6 has single ']'
+
+    if clean_host in ("localhost", "127.0.0.1", "::1"):
+        return {
+            "is_reachable": True,
+            "avg_rtt_ms": 0.0,
+            "status": "loopback_bypass",
+            "privileged_mode": False,
+            "timestamp": now_iso,
+        }
+
+    use_privileged = _can_use_icmp_privileged()
+
+    def _record_and_return(res: dict[str, Any]) -> dict[str, Any]:
+        _LAST_NETWORK_DIAGNOSTICS[clean_host] = res
+        return res
+
+    try:
+        host_obj = await async_ping(
+            address=clean_host,
+            count=1,
+            timeout=ping_timeout,
+            interval=0.2,
+            privileged=use_privileged,
+        )
+
+        if host_obj.is_alive:
+            return _record_and_return({
+                "is_reachable": True,
+                "avg_rtt_ms": getattr(host_obj, "avg_rtt", None),
+                "status": "alive",
+                "privileged_mode": use_privileged,
+                "timestamp": now_iso,
+            })
+
+        _LOGGER.debug(
+            "%s Network diagnostic: Host %s is NOT reachable (UDP ping failed/timed out).",
+            log_prefix,
+            host,
+        )
+        return _record_and_return({
+            "is_reachable": False,
+            "avg_rtt_ms": None,
+            "status": "unreachable_timeout",
+            "privileged_mode": use_privileged,
+            "timestamp": now_iso,
+        })
+
+    except SocketPermissionError as perm_err:
+        _LOGGER.debug(
+            "%s Network diagnostic permission error (ping_group_range restriction): %s. "
+            "Bypassing ping check to protect AC firmware.",
+            log_prefix,
+            perm_err,
+        )
+        return _record_and_return({
+            "is_reachable": True,
+            "avg_rtt_ms": None,
+            "status": "permission_bypassed",
+            "privileged_mode": use_privileged,
+            "timestamp": now_iso,
+        })
+    except (IcmpNameLookupError, ICMPSocketError) as err:
+        _LOGGER.debug(
+            "%s Network diagnostic error for %s: %s", log_prefix, host, err
+        )
+        status_name = (
+            "dns_error" if isinstance(err, IcmpNameLookupError) else "socket_error"
+        )
+        return _record_and_return({
+            "is_reachable": False,
+            "avg_rtt_ms": None,
+            "status": status_name,
+            "privileged_mode": use_privileged,
+            "timestamp": now_iso,
+        })
+    except OSError as e:
+        _LOGGER.debug(
+            "%s Network diagnostic OS error (likely ping_group_range restriction): %s. "
+            "Bypassing ping check to protect AC firmware.",
+            log_prefix,
+            e,
+        )
+        return _record_and_return({
+            "is_reachable": True,
+            "avg_rtt_ms": None,
+            "status": "permission_bypassed",
+            "privileged_mode": use_privileged,
+            "timestamp": now_iso,
+        })
+    except Exception as err:
+        _LOGGER.debug(
+            "%s Unexpected network diagnostic error for %s: %s", log_prefix, host, err
+        )
+        return _record_and_return({
+            "is_reachable": False,
+            "avg_rtt_ms": None,
+            "status": f"error_{type(err).__name__}",
+            "privileged_mode": use_privileged,
+            "timestamp": now_iso,
+        })
 
 
 async def async_get_mac_address(ip_address: str) -> str | None:

--- a/manifest.json
+++ b/manifest.json
@@ -14,5 +14,5 @@
     "requests>=2.32.5",
     "icmplib>=3.0.0"
   ],
-  "version": "10.0.1b6"
+  "version": "10.0.1b7"
 }

--- a/samsung_2878.py
+++ b/samsung_2878.py
@@ -47,6 +47,7 @@ from .helpers import (
     async_check_network_reachability,
     async_create_samsung_ssl_context,
     format_placeholders,
+    get_last_network_diagnostic,
     mask_sensitive_data,
     safe_xml_to_dict,
 )
@@ -275,6 +276,7 @@ class ConnectionSamsung2878(Connection):
 
         # Load the preferred connection settings if they were saved during pairing
         self._last_successful_config = None
+        self._last_icmp_diagnostic: dict[str, Any] | None = None
 
         # Restore last successful SSL config from ConfigEntry data across restarts
         stored = self._config.get("_ssl_config_2878")
@@ -386,6 +388,11 @@ class ConnectionSamsung2878(Connection):
             diag["last_successful_config"] = safe_config
         else:
             diag["last_successful_config"] = None
+
+        diag["network_reachability"] = self._last_icmp_diagnostic or {
+            "is_reachable": None,
+            "status": "not_checked_yet",
+        }
 
         return diag
 
@@ -1171,6 +1178,12 @@ class ConnectionSamsung2878(Connection):
             network_reachable = await async_check_network_reachability(
                 self._cfg.host or "", self.log_prefix
             )
+            self._last_icmp_diagnostic = get_last_network_diagnostic(
+                self._cfg.host
+            ) or {
+                "is_reachable": network_reachable,
+                "status": "alive" if network_reachable else "unreachable_timeout",
+            }
         except Exception as diag_err:
             _LOGGER.debug(
                 "%s Network diagnostic failed: %s", self.log_prefix, diag_err

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,6 +301,32 @@ def auto_mock_network() -> Any:
             new_callable=AsyncMock,
             return_value=True,
         ),
+        patch(
+            "custom_components.climate_ip.helpers.async_get_network_diagnostics",
+            new_callable=AsyncMock,
+            return_value={
+                "is_reachable": True,
+                "avg_rtt_ms": 1.2,
+                "status": "alive",
+                "privileged_mode": False,
+                "timestamp": "2026-09-10T19:00:00+00:00",
+            },
+        ),
+        patch(
+            "custom_components.climate_ip.diagnostics.async_get_network_diagnostics",
+            new_callable=AsyncMock,
+            return_value={
+                "is_reachable": True,
+                "avg_rtt_ms": 1.2,
+                "status": "alive",
+                "privileged_mode": False,
+                "timestamp": "2026-09-10T19:00:00+00:00",
+            },
+        ),
+        patch(
+            "custom_components.climate_ip.diagnostics._can_use_icmp_privileged",
+            return_value=False,
+        ),
     ):
         yield
 

--- a/tests/test_config_flow__basics.py
+++ b/tests/test_config_flow__basics.py
@@ -6793,3 +6793,448 @@ async def test_async_step_initiate_pairing_mutants(hass: HomeAssistant) -> None:
         assert res6.get("step_id") == "initiate_pairing"
         assert res6.get("progress_action") == "initiating_pairing"
         assert res6.get("progress_task") == mock_task
+
+
+async def test_step_intesisbox_show_form_default_schema(hass: HomeAssistant) -> None:
+    """Test async_step_intesisbox renders form with proper schema and defaults when user_input is None."""
+    from custom_components.climate_ip.const import CONF_POLL_INTERVAL
+
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+    flow.flow_data = {CONF_IP_ADDRESS: "10.0.0.1", CONF_MAC: "001122334455"}
+
+    result = await flow.async_step_intesisbox(user_input=None)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "intesisbox"
+    assert result["errors"] == {}
+
+    schema = result["data_schema"]
+    ip_key = next(
+        k for k in schema.schema if getattr(k, "schema", None) == CONF_IP_ADDRESS
+    )
+    assert ip_key.default() == "10.0.0.1"
+
+    mac_key = next(k for k in schema.schema if getattr(k, "schema", None) == CONF_MAC)
+    assert mac_key.description == {"suggested_value": "001122334455"}
+
+    poll_key = next(
+        k for k in schema.schema if getattr(k, "schema", None) == CONF_POLL_INTERVAL
+    )
+    assert poll_key.default() == 60
+
+
+async def test_step_intesisbox_invalid_poll_interval(hass: HomeAssistant) -> None:
+    """Test async_step_intesisbox error handling on invalid poll interval."""
+    from custom_components.climate_ip.const import CONF_POLL_INTERVAL
+
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    result = await flow.async_step_intesisbox(
+        {CONF_IP_ADDRESS: "192.168.1.50", CONF_POLL_INTERVAL: -1}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "intesisbox"
+    assert result["errors"] == {CONF_POLL_INTERVAL: "invalid_poll_interval"}
+
+
+async def test_step_intesisbox_connection_error(hass: HomeAssistant) -> None:
+    """Test async_step_intesisbox handles socket connection failure."""
+    from custom_components.climate_ip.const import CONF_POLL_INTERVAL
+
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    with patch("asyncio.open_connection", side_effect=OSError("Connection failed")):
+        result = await flow.async_step_intesisbox(
+            {CONF_IP_ADDRESS: "192.168.1.50", CONF_POLL_INTERVAL: 30}
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "intesisbox"
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert flow.flow_data[CONF_POLL_INTERVAL] == 30
+
+
+async def test_step_intesisbox_mac_resolution_error(hass: HomeAssistant) -> None:
+    """Test async_step_intesisbox handles MAC resolution error."""
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    mock_reader = AsyncMock()
+    mock_reader.read.return_value = (
+        b"ID:IS-IR-WMP-1,00:1D:C9:A2:C9:11,192.168.1.50,1.9,-44\r\n"
+    )
+    mock_writer = MagicMock()
+    mock_writer.drain = AsyncMock()
+    mock_writer.wait_closed = AsyncMock()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        with patch.object(
+            flow,
+            "_async_resolve_mac_and_set_unique_id",
+            return_value="cannot_resolve_mac",
+        ):
+            result = await flow.async_step_intesisbox(
+                {CONF_IP_ADDRESS: "192.168.1.50"}
+            )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_resolve_mac"}
+
+
+async def test_step_intesisbox_already_configured_abort(hass: HomeAssistant) -> None:
+    """Test async_step_intesisbox aborts when unique id already configured."""
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    from homeassistant.data_entry_flow import AbortFlow
+
+    mock_reader = AsyncMock()
+    mock_reader.read.return_value = (
+        b"ID:IS-IR-WMP-1,001DC9A2C911,192.168.1.50,1.9,-44\r\n"
+    )
+    mock_writer = MagicMock()
+    mock_writer.drain = AsyncMock()
+    mock_writer.wait_closed = AsyncMock()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        with patch.object(
+            flow, "_async_resolve_mac_and_set_unique_id", return_value=None
+        ):
+            with patch.object(
+                flow,
+                "_abort_if_unique_id_configured",
+                side_effect=AbortFlow("already_configured"),
+            ) as mock_abort:
+                with pytest.raises(AbortFlow) as exc_info:
+                    await flow.async_step_intesisbox({CONF_IP_ADDRESS: "192.168.1.50"})
+                assert exc_info.value.reason == "already_configured"
+                mock_abort.assert_called_once()
+
+
+
+async def test_step_intesisbox_success_full(hass: HomeAssistant) -> None:
+    """Test full successful async_step_intesisbox flow with MAC normalized from ID response."""
+    from homeassistant.const import CONF_NAME
+
+    from custom_components.climate_ip.const import (
+        CONF_CONFIG_FILE,
+        CONF_POLL_INTERVAL,
+        DEVICE_TYPE_INTESISBOX,
+        DEVICE_TYPE_TO_CONFIG_FILE,
+    )
+
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    mock_reader = AsyncMock()
+    mock_reader.read.return_value = (
+        b"ID:IS-IR-WMP-1,00:1D:C9:A2:C9:11,192.168.1.50,1.9,-44\r\n"
+    )
+    mock_writer = MagicMock()
+    mock_writer.drain = AsyncMock()
+    mock_writer.wait_closed = AsyncMock()
+
+    with patch(
+        "asyncio.open_connection", return_value=(mock_reader, mock_writer)
+    ) as mock_open:
+        with patch.object(
+            flow, "_async_resolve_mac_and_set_unique_id", return_value=None
+        ) as mock_resolve:
+            result = await flow.async_step_intesisbox(
+                {CONF_IP_ADDRESS: "192.168.1.50", CONF_POLL_INTERVAL: 45}
+            )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "IntesisBox (192.168.1.50)"
+    data = result["data"]
+    assert data[CONF_NAME] == "IntesisBox (192.168.1.50)"
+    assert data[CONF_DEVICE_TYPE] == DEVICE_TYPE_INTESISBOX
+    assert data[CONF_CONFIG_FILE] == DEVICE_TYPE_TO_CONFIG_FILE[DEVICE_TYPE_INTESISBOX]
+    assert data[CONF_CONFIG_FILE] == "intesisbox.yaml"
+    assert data[CONF_TOKEN] == "001dc9a2c911"
+    assert data[CONF_POLL_INTERVAL] == 45
+
+    mock_open.assert_called_once_with("192.168.1.50", 3310)
+    mock_writer.write.assert_called_once_with(b"ID\r\n")
+    mock_writer.drain.assert_awaited_once()
+    mock_reader.read.assert_awaited_once_with(1024)
+    mock_writer.close.assert_called_once()
+    mock_writer.wait_closed.assert_awaited_once()
+    mock_resolve.assert_awaited_once_with(
+        ip_address="192.168.1.50", mac_address="001dc9a2c911"
+    )
+
+
+async def test_step_intesisbox_hyphen_mac_and_fallbacks(hass: HomeAssistant) -> None:
+    """Test hyphenated MAC normalization, fallback token, and user provided MAC preservation."""
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    # 1. Hyphenated MAC in ID packet
+    mock_reader = AsyncMock()
+    mock_reader.read.return_value = (
+        b"ID:IS-IR-WMP-1,AA-BB-CC-DD-EE-FF,192.168.1.60\r\n"
+    )
+    mock_writer = MagicMock()
+    mock_writer.drain = AsyncMock()
+    mock_writer.wait_closed = AsyncMock()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        with patch.object(
+            flow, "_async_resolve_mac_and_set_unique_id", return_value=None
+        ):
+            res1 = await flow.async_step_intesisbox({CONF_IP_ADDRESS: "192.168.1.60"})
+    assert res1["type"] == FlowResultType.CREATE_ENTRY
+    assert res1["data"][CONF_TOKEN] == "aabbccddeeff"
+
+    # 2. No ID packet and no MAC provided -> fallback to 'intesisbox'
+    flow2 = ClimateIpConfigFlow()
+    flow2.hass = hass
+    flow2.context = {}
+
+    mock_reader2 = AsyncMock()
+    mock_reader2.read.return_value = b"NO_ID_HEADER\r\n"
+    mock_writer2 = MagicMock()
+    mock_writer2.drain = AsyncMock()
+    mock_writer2.wait_closed = AsyncMock()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader2, mock_writer2)):
+        with patch.object(
+            flow2, "_async_resolve_mac_and_set_unique_id", return_value=None
+        ):
+            res2 = await flow2.async_step_intesisbox({CONF_IP_ADDRESS: "192.168.1.70"})
+    assert res2["type"] == FlowResultType.CREATE_ENTRY
+    assert res2["data"][CONF_TOKEN] == "intesisbox"
+
+    # 3. User supplied CONF_MAC in input is preserved
+    flow3 = ClimateIpConfigFlow()
+    flow3.hass = hass
+    flow3.context = {}
+
+    mock_reader3 = AsyncMock()
+    mock_reader3.read.return_value = (
+        b"ID:IS-IR-WMP-1,99:88:77:66:55:44,192.168.1.80\r\n"
+    )
+    mock_writer3 = MagicMock()
+    mock_writer3.drain = AsyncMock()
+    mock_writer3.wait_closed = AsyncMock()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader3, mock_writer3)):
+        with patch.object(
+            flow3, "_async_resolve_mac_and_set_unique_id", return_value=None
+        ):
+            res3 = await flow3.async_step_intesisbox(
+                {CONF_IP_ADDRESS: "192.168.1.80", CONF_MAC: "my_custom_mac"}
+            )
+    assert res3["type"] == FlowResultType.CREATE_ENTRY
+    assert res3["data"][CONF_TOKEN] == "my_custom_mac"
+
+
+async def test_step_intesisbox_user_mac_preserved_in_resolve_call(
+    hass: HomeAssistant,
+) -> None:
+    """Kill L371 (mac_val=None), L397 (and→or), L426 (key→None).
+
+    When the user supplies CONF_MAC, mac_val must be set from flow_data so that
+    the 'and not mac_val' guard prevents auto-extraction from the ID response.
+    Assert _async_resolve_mac_and_set_unique_id receives the USER mac, not the
+    auto-extracted one. Also assert CONF_TOKEN equals the user mac via
+    flow_data.get(CONF_MAC, ...) using the correct key.
+    """
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    # Device responds with a DIFFERENT MAC in the ID packet
+    mock_reader = AsyncMock()
+    mock_reader.read.return_value = (
+        b"ID:IS-IR-WMP-1,FFEEDDCCBBAA,192.168.1.90\r\n"
+    )
+    mock_writer = MagicMock()
+    mock_writer.drain = AsyncMock()
+    mock_writer.wait_closed = AsyncMock()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        with patch.object(
+            flow, "_async_resolve_mac_and_set_unique_id", return_value=None
+        ) as mock_resolve:
+            result = await flow.async_step_intesisbox(
+                {CONF_IP_ADDRESS: "192.168.1.90", CONF_MAC: "user_mac_value"}
+            )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    # Kill L371 + L397: mac_val = flow_data.get(CONF_MAC) must be truthy,
+    # preventing 'and not mac_val' block from overwriting with auto-extracted MAC
+    mock_resolve.assert_awaited_once_with(
+        ip_address="192.168.1.90", mac_address="user_mac_value"
+    )
+
+    # Kill L426: flow_data.get(CONF_MAC, ...) must use CONF_MAC as key, not None
+    assert result["data"][CONF_TOKEN] == "user_mac_value"
+
+
+async def test_step_intesisbox_exact_timeout_values(hass: HomeAssistant) -> None:
+    """Kill L388 (timeout=5.0→6.0) and L392 (timeout=5.0→None).
+
+    Patch asyncio.wait_for to track all timeout kwarg values and assert
+    both the open_connection and reader.read calls use exactly 5.0.
+    """
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    mock_reader = AsyncMock()
+    mock_reader.read.return_value = (
+        b"ID:IS-IR-WMP-1,001DC9A2C911,192.168.1.50\r\n"
+    )
+    mock_writer = MagicMock()
+    mock_writer.drain = AsyncMock()
+    mock_writer.wait_closed = AsyncMock()
+
+    timeout_values: list = []
+    _original_wait_for = asyncio.wait_for
+
+    async def _tracking_wait_for(coro, *, timeout=None):  # noqa: ASYNC109
+        timeout_values.append(timeout)
+        return await _original_wait_for(coro, timeout=timeout)
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        with patch("asyncio.wait_for", new=_tracking_wait_for):
+            with patch.object(
+                flow, "_async_resolve_mac_and_set_unique_id", return_value=None
+            ):
+                result = await flow.async_step_intesisbox(
+                    {CONF_IP_ADDRESS: "192.168.1.50"}
+                )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # Both wait_for calls must use timeout=5.0
+    assert timeout_values == [5.0, 5.0], (
+        f"Expected [5.0, 5.0], got {timeout_values}"
+    )
+
+
+async def test_step_intesisbox_malformed_id_no_model_field(
+    hass: HomeAssistant,
+) -> None:
+    """Kill L398 (regex [^,]+→[^,]*).
+
+    Send an ID packet with an empty model field ('ID:,MAC,...'). The regex
+    uses [^,]+ which requires at least one non-comma char between 'ID:' and
+    the first comma. An empty model means [^,]+ does NOT match → mac_val stays
+    None → token falls back to 'intesisbox'. The [^,]* mutant would match the
+    empty field and extract the MAC → different token.
+    """
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    mock_reader = AsyncMock()
+    # Empty model field: "ID:" followed immediately by comma
+    mock_reader.read.return_value = b"ID:,AABBCCDDEEFF,192.168.1.95\r\n"
+    mock_writer = MagicMock()
+    mock_writer.drain = AsyncMock()
+    mock_writer.wait_closed = AsyncMock()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        with patch.object(
+            flow, "_async_resolve_mac_and_set_unique_id", return_value=None
+        ) as mock_resolve:
+            result = await flow.async_step_intesisbox(
+                {CONF_IP_ADDRESS: "192.168.1.95"}
+            )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # [^,]+ does NOT match empty model → mac_val stays None → fallback token
+    assert result["data"][CONF_TOKEN] == "intesisbox"
+    # mac_val passed to resolve is also None (no extraction happened)
+    mock_resolve.assert_awaited_once_with(
+        ip_address="192.168.1.95", mac_address=None
+    )
+
+
+async def test_step_intesisbox_schema_empty_flow_data_defaults(
+    hass: HomeAssistant,
+) -> None:
+    """Kill L437 (default=""→None) and L441 (suggested_value=""→None).
+
+    Render the form with completely empty flow_data so that the fallback
+    defaults in flow_data.get(CONF_IP_ADDRESS, "") and
+    flow_data.get(CONF_MAC, "") are exercised. Assert they are empty strings,
+    not None.
+    """
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+    flow.flow_data = {}  # Completely empty → fallback defaults exercised
+
+    result = await flow.async_step_intesisbox(user_input=None)
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "intesisbox"
+
+    schema = result["data_schema"]
+
+    # Kill L437: default must be "" not None
+    ip_key = next(
+        k for k in schema.schema if getattr(k, "schema", None) == CONF_IP_ADDRESS
+    )
+    assert ip_key.default() == ""
+
+    # Kill L441: suggested_value must be "" not None
+    mac_key = next(
+        k for k in schema.schema if getattr(k, "schema", None) == CONF_MAC
+    )
+    assert mac_key.description == {"suggested_value": ""}
+
+
+async def test_step_intesisbox_ascii_decode_non_ascii_bytes(
+    hass: HomeAssistant,
+) -> None:
+    """Kill L393 (decode 'ascii' removed → defaults to utf-8).
+
+    Send an ID response with non-ASCII bytes (\\xc3\\x84 = UTF-8 'Ä') placed
+    between 'I' and 'D:'. Under ASCII decode with errors='ignore', the invalid
+    bytes are stripped → "ID:MODEL,001DC9A2C911,..." → MAC extracted.
+    Under UTF-8 decode (mutant), \\xc3\\x84 becomes 'Ä' → "IÄD:MODEL,..." →
+    "ID:" NOT found → no MAC extraction → different token.
+    """
+    flow = ClimateIpConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+
+    mock_reader = AsyncMock()
+    # Non-ASCII bytes \xc3\x84 (UTF-8 'Ä') between 'I' and 'D:'
+    # ASCII+ignore: \xc3\x84 stripped → "ID:MODEL,001DC9A2C911,192.168.1.50\r\n"
+    # UTF-8+ignore: \xc3\x84 → 'Ä' → "IÄD:MODEL,001DC9A2C911,192.168.1.50\r\n"
+    mock_reader.read.return_value = (
+        b"I\xc3\x84D:MODEL,001DC9A2C911,192.168.1.50\r\n"
+    )
+    mock_writer = MagicMock()
+    mock_writer.drain = AsyncMock()
+    mock_writer.wait_closed = AsyncMock()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        with patch.object(
+            flow, "_async_resolve_mac_and_set_unique_id", return_value=None
+        ) as mock_resolve:
+            result = await flow.async_step_intesisbox(
+                {CONF_IP_ADDRESS: "192.168.1.50"}
+            )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # With ASCII decode (original), "ID:" is found and MAC is extracted
+    assert result["data"][CONF_TOKEN] == "001dc9a2c911"
+    mock_resolve.assert_awaited_once_with(
+        ip_address="192.168.1.50", mac_address="001dc9a2c911"
+    )
+

--- a/tests/test_connection_intesisbox__yaml.py
+++ b/tests/test_connection_intesisbox__yaml.py
@@ -1433,6 +1433,908 @@ async def test_intesisbox_swing_mode_dynamic_limits(hass: HomeAssistant) -> None
     assert climate_state2.swing_mode == "1"
 
 
+# ---------------------------------------------------------------------------
+# 11. Targeted Mutant Killing & Comprehensive Coverage Tests
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_intesisbox_set_update_callback_controller_fallback_and_linking() -> None:
+    """Kill L216-217 mutants in set_update_callback.
+
+    Test callback fallback to controller.on_push_update_callback when None is passed,
+    and ensure explicit callback is preserved and not overwritten.
+    """
+    conn = ConnectionIntesisBox(config={CONF_IP_ADDRESS: "127.0.0.1"}, logger=_LOGGER)
+
+    # 1. Controller has callable on_push_update_callback
+    mock_controller = MagicMock()
+    controller_cb = AsyncMock()
+    mock_controller.on_push_update_callback = controller_cb
+    conn.set_controller_ref(mock_controller)
+
+    # Pass None: must link controller callback
+    conn.set_update_callback(None)
+    assert conn._update_callback == controller_cb
+
+    # 2. Pass explicit user callback: must NOT overwrite with controller callback
+    user_cb = AsyncMock()
+    conn.set_update_callback(user_cb)
+    assert conn._update_callback == user_cb
+
+    # 3. Controller has non-callable on_push_update_callback: must stay None
+    mock_controller2 = MagicMock()
+    mock_controller2.on_push_update_callback = "not_a_callable"
+    conn2 = ConnectionIntesisBox(config={CONF_IP_ADDRESS: "127.0.0.1"}, logger=_LOGGER)
+    conn2.set_controller_ref(mock_controller2)
+    conn2.set_update_callback(None)
+    assert conn2._update_callback is None
+
+
+def test_intesisbox_load_from_yaml_handshake_single_string() -> None:
+    """Kill L153 untested mutants in load_from_yaml.
+
+    Test when handshake_commands is configured as a single string instead of a list.
+    """
+    conn = ConnectionIntesisBox(config={CONF_IP_ADDRESS: "127.0.0.1"}, logger=_LOGGER)
+    success = conn.load_from_yaml(
+        {"handshake_commands": "STATUS,{{ac_num}}"},
+        None,
+    )
+    assert success is True
+    assert conn._handshake_commands == [f"STATUS,{conn._ac_num}"]
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_process_line_ack_err_without_pending_ack() -> None:
+    """Kill L325 and L330 mutants in _process_incoming_line.
+
+    When _pending_ack is None, receiving ACK or ERR must safely return without
+    AttributeError (mutant mutates 'and not' to 'or not' which calls None.done()).
+    """
+    conn = ConnectionIntesisBox(config={CONF_IP_ADDRESS: "127.0.0.1"}, logger=_LOGGER)
+    conn._pending_ack = None
+
+    # Should not raise AttributeError: 'NoneType' object has no attribute 'done'
+    conn._process_incoming_line("ACK")
+    conn._process_incoming_line("ERR")
+    assert conn._pending_ack is None
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_process_line_splits_with_multiple_colons_and_commas(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Kill L321, L343, L373, and L381 mutants in _process_incoming_line.
+
+    Test that protocol splitting uses maxsplit=1:
+    - L321: verify RX logger format contains 'RX:'
+    - L343: LIMITS with extra colon in payload does not fail unpacking
+    - L373: STATUS / CHN with extra colon does not fail unpacking
+    - L381: UID,val item with extra comma does not fail unpacking
+    """
+    conn = ConnectionIntesisBox(config={CONF_IP_ADDRESS: "127.0.0.1"}, logger=_LOGGER)
+
+    with caplog.at_level(logging.DEBUG):
+        # L321: test logger RX formatting
+        conn._process_incoming_line("ACK")
+        assert "RX: 'ACK'" in caplog.text
+
+    # L343: LIMITS with extra colon in payload: "LIMITS:FANSP,[AUTO,1:2,3]"
+    conn._process_incoming_line("LIMITS:FANSP,[AUTO,1:2,3]")
+    assert conn._limits.get("FANSP") == "[AUTO,1:2,3]"
+    assert conn._device_status.get("_LIMITS_FANSP") == "[AUTO,1:2,3]"
+
+    # L373: STATUS line with extra colon: "STATUS,1:EXTRA:COLON,VAL"
+    conn._process_incoming_line("STATUS,1:EXTRA:COLON,VAL")
+    assert conn._device_status.get("EXTRA:COLON") == "VAL"
+
+    # L381: Item with extra comma in value: "1:DATA,VAL1,VAL2"
+    conn._process_incoming_line("1:DATA,VAL1,VAL2")
+    assert conn._device_status.get("DATA") == "VAL1,VAL2"
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_process_line_awaitable_object_and_hass_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Kill L354, L397, L398, and L403 mutants in _process_incoming_line.
+
+    - L354 & L397: Non-coroutine awaitables (custom __await__) must be scheduled
+      via hass.async_create_task (mutant changes 'or hasattr(__await__)' to 'and hasattr(__await__)').
+    - L398: If self._hass is not None but lacks async_create_task, fall back to asyncio.create_task.
+    - L403: Callback raising exception is caught and logged as error.
+    """
+    class CustomAwaitable:
+        def __await__(self):
+            async def _dummy():
+                return None
+            return _dummy().__await__()
+
+    conn = ConnectionIntesisBox(config={CONF_IP_ADDRESS: "127.0.0.1"}, logger=_LOGGER)
+    mock_hass = MagicMock()
+    conn._hass = mock_hass
+
+    # 1. Test L397 with custom awaitable in state update
+    custom_state_awaitable = CustomAwaitable()
+    conn.set_update_callback(lambda data: custom_state_awaitable)
+    conn._process_incoming_line("1:ONOFF,ON")
+    mock_hass.async_create_task.assert_called_with(custom_state_awaitable)
+
+    # 2. Test L354 with custom awaitable in LIMITS update
+    custom_limits_awaitable = CustomAwaitable()
+    conn.set_update_callback(lambda data: custom_limits_awaitable)
+    conn._process_incoming_line("LIMITS:MODE,[AUTO,COOL]")
+    mock_hass.async_create_task.assert_called_with(custom_limits_awaitable)
+
+    # 3. Test L398: hass object without async_create_task falls back to asyncio.create_task
+    coro_executed = False
+
+    async def real_coro():
+        nonlocal coro_executed
+        coro_executed = True
+
+    conn._hass = object()  # Truthy, but lacks async_create_task
+    conn.set_update_callback(lambda data: real_coro())
+    conn._process_incoming_line("1:ONOFF,ON")
+    await asyncio.sleep(0.02)
+    assert coro_executed is True
+
+    # 4. Test L403: Callback raising exception
+    def broken_callback(data):
+        raise RuntimeError("Callback explosion")
+
+    conn.set_update_callback(broken_callback)
+    with caplog.at_level(logging.ERROR):
+        conn._process_incoming_line("1:ONOFF,OFF")
+        assert "Failed dispatching push update" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_loop_breaker_state_node_and_custom_rule_attributes(
+    hass: HomeAssistant,
+) -> None:
+    """Kill L412, L420, L421, L422, and L423 mutants in loop breaker evaluation.
+
+    - L412: rule using 'state_node' instead of 'node'.
+    - L420: custom non-default fallback_value ("CUSTOM_STOP").
+    - L421: custom non-default threshold (2 instead of default 3).
+    - L422: custom non-default window_seconds (1.5 instead of default 3.0).
+    - L423: custom non-default prune_values (["CUSTOM_PRUNE"]).
+    """
+    hass.async_create_task.side_effect = asyncio.create_task
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+        hass=hass,
+    )
+    conn.load_from_yaml(
+        {
+            "loop_breakers": [
+                {
+                    "state_node": "FANSP",  # Tests L412
+                    "fallback_value": "CUSTOM_STOP",  # Tests L420
+                    "fallback_command": "SET,1:FANSP,CUSTOM_STOP",
+                    "threshold": 2,  # Tests L421 (triggers on 2 alternations / 3 values)
+                    "window_seconds": 1.5,  # Tests L422
+                    "prune_values": ["CUSTOM_PRUNE"],  # Tests L423
+                    "prune_command_template": "LIMITS:FANSP,{{new_limits}}",
+                }
+            ]
+        },
+        None,
+    )
+    conn._limits["FANSP"] = "[CUSTOM_STOP,CUSTOM_PRUNE,OTHER]"
+
+    sent_commands: list[str] = []
+
+    async def fake_send_raw(payload: str) -> None:
+        sent_commands.append(payload)
+
+    conn._send_raw = fake_send_raw
+
+    # Send 3 alternating values: CUSTOM_PRUNE -> CUSTOM_STOP -> CUSTOM_PRUNE (2 alternations)
+    conn._process_incoming_line("CHN,1:FANSP,CUSTOM_PRUNE")
+    conn._process_incoming_line("CHN,1:FANSP,CUSTOM_STOP")
+    conn._process_incoming_line("CHN,1:FANSP,CUSTOM_PRUNE")
+
+    await asyncio.sleep(0.05)
+
+    assert "SET,1:FANSP,CUSTOM_STOP\r\n" in sent_commands
+    assert "LIMITS:FANSP,[CUSTOM_STOP,OTHER]\r\n" in sent_commands
+    assert conn._limits["FANSP"] == "[CUSTOM_STOP,OTHER]"
+    assert conn._device_status["FANSP"] == "CUSTOM_STOP"
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_loop_breaker_window_purging_and_alternation_boundary() -> None:
+    """Kill L429, L433, and L451 mutants in _evaluate_oscillation_rule.
+
+    - L429: Expired history entries outside window_seconds must be pruned.
+    - L433: len(active_hist) >= threshold + 1 boundary.
+    - L451: Alternations loop starts at index 1 (mutant range(len(...)) falsely compares index 0 to -1).
+    """
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    rule = {
+        "node": "FANSP",
+        "fallback_value": "AUTO",
+        "threshold": 4,  # Requires 4 alternations (at least 5 values)
+        "window_seconds": 2.0,
+    }
+    conn._loop_breakers = [rule]
+
+    sent_commands: list[str] = []
+
+    async def fake_send(payload: str) -> None:
+        sent_commands.append(payload)
+
+    conn._send_raw = fake_send
+
+    # 1. L429: History window purging test
+    now = time.monotonic()
+    # Inject old entry 10 seconds ago
+    conn._node_history["FANSP"] = [(now - 10.0, "OLD_VAL")]
+    conn._evaluate_oscillation_rule("FANSP", "VAL1", rule)
+    # The old entry must be purged, leaving only VAL1
+    assert len(conn._node_history["FANSP"]) == 1
+    assert conn._node_history["FANSP"][0][1] == "VAL1"
+
+    # 2. L433 & L451: Test 4 alternating values ["A", "B", "A", "B"] with threshold=4
+    # Real alternations: A->B (1), B->A (2), A->B (3) = 3 alternations.
+    # Mutant range(len(...)) at i=0 compares active_hist[0] ("A") with active_hist[-1] ("B"),
+    # falsely adding a 4th alternation and triggering prematurely!
+    conn._node_history.clear()
+    sent_commands.clear()
+
+    conn._process_incoming_line("CHN,1:FANSP,A")
+    conn._process_incoming_line("CHN,1:FANSP,B")
+    conn._process_incoming_line("CHN,1:FANSP,A")
+    conn._process_incoming_line("CHN,1:FANSP,B")
+
+    await asyncio.sleep(0.02)
+    # Must NOT have triggered because 3 alternations < threshold (4)
+    assert len(sent_commands) == 0
+
+    # 3. Add 5th alternating value "A" -> 4 alternations reached, triggers!
+    conn._process_incoming_line("CHN,1:FANSP,A")
+    await asyncio.sleep(0.02)
+    assert conn._device_status["FANSP"] == "AUTO"
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_loop_breaker_else_branch_and_value_selection() -> None:
+    """Kill L438, L441, L442, L443, L446-447, and L449 mutants.
+
+    Test oscillation between two values where NEITHER is in prune_values
+    and NEITHER is fallback_value. This executes the L446-447 else branch.
+    """
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    rule = {
+        "node": "FANSP",
+        "fallback_value": "AUTO",
+        "fallback_command": "SET,1:FANSP,AUTO",
+        "prune_values": ["1"],  # '2' and '3' are not in prune_values
+        "threshold": 3,
+        "window_seconds": 5.0,
+    }
+    conn._loop_breakers = [rule]
+    conn._limits["FANSP"] = "[AUTO,1,2,3,4]"
+
+    sent_commands: list[str] = []
+
+    async def fake_send(payload: str) -> None:
+        sent_commands.append(payload)
+
+    conn._send_raw = fake_send
+
+    # Alternate between '2' and '3' (neither is '1', neither is 'AUTO')
+    conn._process_incoming_line("CHN,1:FANSP,2")
+    conn._process_incoming_line("CHN,1:FANSP,3")
+    conn._process_incoming_line("CHN,1:FANSP,2")
+    conn._process_incoming_line("CHN,1:FANSP,3")
+
+    await asyncio.sleep(0.05)
+
+    # Fallback command sent, but neither 2 nor 3 is pruned
+    assert "SET,1:FANSP,AUTO\r\n" in sent_commands
+    assert conn._limits["FANSP"] == "[AUTO,1,2,3,4]"
+    assert conn._device_status["FANSP"] == "AUTO"
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_loop_breaker_without_hass_and_callback_and_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Kill L465, L472-473, L526, L527, and L532 mutants in loop breaker execution.
+
+    - L465 & L472-473: Connection with hass=None creates asyncio.create_task.
+    - L526 & L527: Update callback receives payload during loop break.
+    - L532: Error in _send_raw during loop break is logged.
+    """
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+        hass=None,  # hass=None forces L472-473 branch
+    )
+    callback_received: list[dict[str, Any]] = []
+
+    async def mock_cb(payload: dict[str, Any]) -> None:
+        callback_received.append(payload)
+
+    conn.set_update_callback(mock_cb)
+
+    # 1. Normal execution with callback
+    rule = {
+        "node": "FANSP",
+        "fallback_value": "AUTO",
+        "fallback_command": "SET,1:FANSP,AUTO",
+        "threshold": 2,
+        "window_seconds": 3.0,
+    }
+    conn._loop_breakers = [rule]
+    sent_commands: list[str] = []
+
+    async def fake_send(payload: str) -> None:
+        sent_commands.append(payload)
+
+    conn._send_raw = fake_send
+
+    conn._process_incoming_line("CHN,1:FANSP,1")
+    conn._process_incoming_line("CHN,1:FANSP,AUTO")
+    conn._process_incoming_line("CHN,1:FANSP,1")
+
+    await asyncio.sleep(0.05)
+
+    assert "SET,1:FANSP,AUTO\r\n" in sent_commands
+    assert len(callback_received) >= 1
+    assert callback_received[-1].get("FANSP") == "AUTO"
+
+    # 2. Test L532: Exception in _send_raw during loop break
+    async def broken_send(payload: str) -> None:
+        raise OSError("Socket write failure")
+
+    conn._send_raw = broken_send
+    with caplog.at_level(logging.ERROR):
+        await conn._async_execute_loop_break("FANSP", "1", "AUTO", rule)
+        assert "Error executing loop breaker" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_async_connect_handshake_failure_and_timeout(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Kill L268 and L277 mutants in async_connect.
+
+    - L268: Initial handshake send exception is caught and logged as warning.
+    - L277: Handshake wait timeout is caught cleanly without error.
+    """
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    conn._connect_timeout = 1.0
+    conn._handshake_timeout = 0.01
+
+    mock_reader = AsyncMock()
+    mock_reader.readline = AsyncMock(return_value=b"")
+    mock_writer = MagicMock()
+    mock_writer.is_closing.return_value = False
+    mock_writer.drain = AsyncMock()
+    mock_writer.write = MagicMock()
+
+    # 1. Test L268: handshake command send fails
+    async def broken_send(payload: str) -> None:
+        raise OSError("Handshake network error")
+
+    conn._send_raw = broken_send
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        with caplog.at_level(logging.WARNING):
+            await conn.async_connect()
+            assert "Initial handshake send failed" in caplog.text
+
+    await conn.close()
+
+    # 2. Test L277: Handshake wait timeout logs debug message
+    conn2 = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    conn2._connect_timeout = 1.0
+    conn2._handshake_timeout = 0.01
+
+    mock_reader2 = AsyncMock()
+    # Keep readline waiting
+    async def hanging_read() -> bytes:
+        await asyncio.sleep(999)
+        return b""
+    mock_reader2.readline = AsyncMock(side_effect=hanging_read)
+
+    with patch("asyncio.open_connection", return_value=(mock_reader2, mock_writer)):
+        with caplog.at_level(logging.DEBUG):
+            await conn2.async_connect()
+            assert "Handshake wait timed out" in caplog.text
+
+    await conn2.close()
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_reader_loop_eof_and_unexpected_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Kill L297, L311, and L312 mutants in _reader_loop.
+
+    - L297: Remote closes TCP connection (EOF readline returns b"") -> warning logged, loop breaks.
+    - L311-312: Unexpected exception in reader loop while not closing -> error logged.
+    """
+    # 1. Test L297: EOF handling
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    mock_reader = AsyncMock()
+    mock_reader.readline.return_value = b""  # EOF
+    conn._reader = mock_reader
+    conn._is_connected = True
+
+    with caplog.at_level(logging.WARNING):
+        await conn._reader_loop()
+        assert "Remote closed TCP connection (EOF)" in caplog.text
+        assert conn._is_connected is False
+
+    # 2. Test L311-312: Unexpected exception in reader loop
+    conn2 = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    mock_reader2 = AsyncMock()
+    mock_reader2.readline.side_effect = ConnectionResetError("Connection lost abruptly")
+    conn2._reader = mock_reader2
+    conn2._closing = False
+    conn2._is_connected = True
+
+    with caplog.at_level(logging.ERROR):
+        await conn2._reader_loop()
+        assert "Unexpected error in reader loop" in caplog.text
+        assert conn2._is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_async_execute_all_branches() -> None:
+    """Kill L559, L564, L569, L572-573, L577-578, L584-587, and L589-592 in async_execute.
+
+    - L559: _is_poll=True with error in _send_raw.
+    - L564: data=None or data="" returns current status cache.
+    - L569: multi-line data with empty lines.
+    - L577-578: IntesisBox returns ERR rejection -> raises CannotConnect.
+    - L584-587: Command success updates local status cache with split parts.
+    - L589-592: Command timeout waiting for ACK -> raises CannotConnect.
+    """
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    conn._is_connected = True
+    conn._writer = MagicMock()
+    conn._writer.is_closing.return_value = False
+    conn._command_timeout = 0.05
+
+    sent_cmds: list[str] = []
+
+    # 1. Test L564: data=None and empty data
+    conn._device_status = {"ONOFF": "ON"}
+    resp1, _ = await conn.async_execute(None, None, data=None, headers=None)
+    assert json.loads(resp1).get("ONOFF") == "ON"
+
+    resp2, _ = await conn.async_execute(None, None, data="", headers=None)
+    assert json.loads(resp2).get("ONOFF") == "ON"
+
+    # 2. Test L559: Polling with error in _send_raw
+    async def failing_send(payload: str) -> None:
+        raise OSError("Poll send failed")
+
+    conn._send_raw = failing_send
+    resp_poll, _ = await conn.async_execute(None, None, data=None, headers=None, _is_poll=True)
+    assert json.loads(resp_poll).get("ONOFF") == "ON"
+
+    # 3. Test L569, L572-573, L584-587: Sequential execution with ACK & cache update
+    async def ack_send(payload: str) -> None:
+        sent_cmds.append(payload)
+        # Simulate background ACK response from reader loop
+        if conn._pending_ack and not conn._pending_ack.done():
+            conn._pending_ack.set_result(True)
+
+    conn._send_raw = ack_send
+    # Multi-line with blank lines (tests L569 stripping)
+    cmd_data = "\n\nSET,1:FANSP,AUTO\nSET,1:MODE,COOL\n\n"
+    resp_ack, _ = await conn.async_execute(None, None, data=cmd_data, headers=None)
+    assert "SET,1:FANSP,AUTO\r\n" in sent_cmds
+    assert "SET,1:MODE,COOL\r\n" in sent_cmds
+    status = json.loads(resp_ack)
+    assert status.get("FANSP") == "AUTO"
+    assert status.get("MODE") == "COOL"
+
+    # 4. Test L577-578: Command rejected with ERR
+    async def err_send(payload: str) -> None:
+        if conn._pending_ack and not conn._pending_ack.done():
+            conn._pending_ack.set_result(False)
+
+    conn._send_raw = err_send
+    with pytest.raises(CannotConnect, match="rejected with ERR"):
+        await conn.async_execute(None, None, data="SET,1:SETPTEMP,999", headers=None)
+
+    # 5. Test L589-592: Command timeout waiting for ACK
+    async def hanging_cmd(payload: str) -> None:
+        pass  # Never set _pending_ack
+
+    conn._send_raw = hanging_cmd
+    with pytest.raises(CannotConnect, match="Timed out waiting for ACK"):
+        await conn.async_execute(None, None, data="SET,1:SETPTEMP,220", headers=None)
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_async_execute_loop_break_direct() -> None:
+    """Kill L489-513 and L526-527 mutants in _async_execute_loop_break directly.
+
+    Tests exact limits string formatting, template substitution, bracket stripping,
+    dictionary updates, and awaitable callback scheduling.
+    """
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    sent_cmds: list[str] = []
+
+    async def fake_send(payload: str) -> None:
+        sent_cmds.append(payload)
+
+    conn._send_raw = fake_send
+
+    rule = {
+        "fallback_command": "SET,1:FANSP,AUTO",
+        "prune_values": ["1"],
+        "prune_command_template": "LIMITS:FANSP,{{new_limits}}",
+    }
+    conn._limits["FANSP"] = "[AUTO,1,2,3,4]"
+    conn._device_status["_LIMITS_FANSP"] = "[AUTO,1,2,3,4]"
+
+    # Test callback with non-coroutine awaitable (kills L526-527)
+    class CustomAwaitable:
+        def __init__(self) -> None:
+            self.done = False
+
+        def __await__(self):
+            self.done = True
+            async def _d():
+                return None
+            return _d().__await__()
+
+    custom_cb = CustomAwaitable()
+    mock_hass = MagicMock()
+    conn._hass = mock_hass
+    conn.set_update_callback(lambda d: custom_cb)
+
+    # 1. Execute loop break with eligible pruning
+    await conn._async_execute_loop_break("FANSP", "1", "AUTO", rule)
+
+    # Assert exact command format (kills L490, L510, L513)
+    assert sent_cmds == [
+        "SET,1:FANSP,AUTO\r\n",
+        "LIMITS:FANSP,[AUTO,2,3,4]\r\n",
+    ]
+    # Assert exact limits string (kills L494, L497, L498, L500)
+    assert conn._limits["FANSP"] == "[AUTO,2,3,4]"
+    assert conn._device_status["_LIMITS_FANSP"] == "[AUTO,2,3,4]"
+    assert conn._device_status["FANSP"] == "AUTO"
+
+    # Assert callback scheduled via mock_hass (kills L526-527)
+    mock_hass.async_create_task.assert_called_with(custom_cb)
+
+    # 2. Bad val not in prune_values -> no pruning commands sent
+    sent_cmds.clear()
+    await conn._async_execute_loop_break("FANSP", "2", "AUTO", rule)
+    assert sent_cmds == ["SET,1:FANSP,AUTO\r\n"]
+
+    # 3. No prune_command_template -> no pruning commands sent
+    sent_cmds.clear()
+    rule_no_template = {"fallback_command": "SET,1:FANSP,AUTO", "prune_values": ["1"]}
+    await conn._async_execute_loop_break("FANSP", "1", "AUTO", rule_no_template)
+    assert sent_cmds == ["SET,1:FANSP,AUTO\r\n"]
+
+    # 4. Empty limits cache -> no pruning commands sent
+    sent_cmds.clear()
+    conn._limits["FANSP"] = ""
+    await conn._async_execute_loop_break("FANSP", "1", "AUTO", rule)
+    assert sent_cmds == ["SET,1:FANSP,AUTO\r\n"]
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_evaluate_oscillation_rule_logging_and_boundaries(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Kill L420-423, L429, L433, L438, L441-443, L446-447, L449, and L451 mutants.
+
+    Verifies exact warning log output with distinct values, threshold boundary,
+    and history window inclusion.
+    """
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    sent_cmds: list[str] = []
+
+    async def fake_send(payload: str) -> None:
+        sent_cmds.append(payload)
+
+    conn._send_raw = fake_send
+
+    rule = {
+        "node": "FANSP",
+        "fallback_value": "AUTO",
+        "fallback_command": "SET,1:FANSP,AUTO",
+        "prune_values": ["1"],
+        "threshold": 3,
+        "window_seconds": 3.0,
+    }
+    conn._loop_breakers = [rule]
+    conn._limits["FANSP"] = "[AUTO,1,2,3,4]"
+
+    # 1. Boundary: exactly threshold (3) updates must NOT trigger loop breaker (kills L433)
+    conn._process_incoming_line("CHN,1:FANSP,1")
+    conn._process_incoming_line("CHN,1:FANSP,AUTO")
+    conn._process_incoming_line("CHN,1:FANSP,1")
+    await asyncio.sleep(0.01)
+    assert len(sent_cmds) == 0
+
+    # 2. 4th update (threshold + 1) triggers with prune match
+    with caplog.at_level(logging.WARNING):
+        conn._process_incoming_line("CHN,1:FANSP,AUTO")
+        await asyncio.sleep(0.02)
+        assert len(sent_cmds) > 0
+        # Kills L441 (other_val == bad_val), L442, L443: must say between '1' and 'AUTO'
+        assert "oscillation detected between '1' and 'AUTO'" in caplog.text
+
+    # 3. Else branch: neither in prune_values, neither is fallback (kills L446, L447, L449)
+    sent_cmds.clear()
+    caplog.clear()
+    conn._node_history.clear()
+    conn._process_incoming_line("CHN,1:FANSP,2")
+    conn._process_incoming_line("CHN,1:FANSP,3")
+    conn._process_incoming_line("CHN,1:FANSP,2")
+    with caplog.at_level(logging.WARNING):
+        conn._process_incoming_line("CHN,1:FANSP,3")
+        await asyncio.sleep(0.02)
+        assert len(sent_cmds) > 0
+        # In else branch, bad_val is last item ('3') and other_val is '2'
+        assert "oscillation detected between '3' and '2'" in caplog.text
+
+    # 4. History window exact boundary (kills L429 <= vs <)
+    with patch("time.monotonic", return_value=100.0):
+        # Entry exactly at window_seconds boundary: now - t == 3.0 (100.0 - 97.0 == 3.0)
+        conn._node_history["FANSP"] = [(97.0, "BOUNDARY_VAL")]
+        conn._evaluate_oscillation_rule("FANSP", "NEW_VAL", rule)
+        # With <= window_seconds (3.0 <= 3.0), BOUNDARY_VAL is kept (2 items); with < it is discarded
+        assert any(v == "BOUNDARY_VAL" for _, v in conn._node_history["FANSP"])
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_reader_loop_closing_and_ascii_decode() -> None:
+    """Kill L293 (while not self._closing or self._reader) and L302 (ascii decode) mutants."""
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    # 1. Test immediate exit when _closing=True (kills L293 'while not self._closing or self._reader')
+    conn._closing = True
+    mock_reader = AsyncMock()
+    conn._reader = mock_reader
+    await conn._reader_loop()
+    mock_reader.readline.assert_not_called()
+
+    # 2. Test ASCII decoding with errors='ignore' vs UTF-8 (kills L302 decode default mutant)
+    conn._closing = False
+    mock_reader = AsyncMock()
+    # \xc3\x84 is invalid ASCII (ignored to "") but valid UTF-8 ("Ä")
+    mock_reader.readline = AsyncMock(
+        side_effect=[b"CHN,1:FANSP,\xc3\x84VALID\r\n", b""]
+    )
+    conn._reader = mock_reader
+
+    processed: list[str] = []
+    conn._process_incoming_line = MagicMock(side_effect=processed.append)
+
+    await conn._reader_loop()
+    assert processed == ["CHN,1:FANSP,VALID"]
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_evaluate_oscillation_rule_precision_spying() -> None:
+    """Kill L420-423 defaults, L438, L443, L446, L451, and L465 in _evaluate_oscillation_rule."""
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    spy_loop_break = AsyncMock()
+    conn._async_execute_loop_break = spy_loop_break
+
+    # 1. Rule without fallback_value (defaults to "AUTO", kills L420)
+    rule_no_fb = {"threshold": 3, "window_seconds": 3.0, "prune_values": []}
+    for val in ["MANUAL", "AUTO", "MANUAL", "AUTO"]:
+        conn._evaluate_oscillation_rule("FANSP", val, rule_no_fb)
+    spy_loop_break.assert_called_with("FANSP", "MANUAL", "AUTO", rule_no_fb)
+
+    # 2. Rule without threshold (defaults to 3, kills L421)
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_no_th = {"fallback_value": "AUTO", "window_seconds": 3.0, "prune_values": []}
+    for val in ["1", "2", "1"]:
+        conn._evaluate_oscillation_rule("FANSP", val, rule_no_th)
+    assert not spy_loop_break.called
+    conn._evaluate_oscillation_rule("FANSP", "2", rule_no_th)
+    assert spy_loop_break.called
+
+    # 3. Rule without prune_values and without window_seconds (kills defaults)
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_minimal = {"fallback_value": "AUTO", "threshold": 3}
+    for val in ["1", "2", "1", "2"]:
+        conn._evaluate_oscillation_rule("FANSP", val, rule_minimal)
+    assert spy_loop_break.called
+
+    # Rule with non-default window_seconds (kills L426 rule.get mutants [22, 26, 27, 28])
+    # Case A: window_seconds=2.0 with span 2.4s (10.0 -> 12.4).
+    # Original: span 2.4s > 2.0s -> first item purged, 3 items < 4 -> does NOT trigger.
+    # Mutants (using default 3.0s): span 2.4s <= 3.0s -> 4 items preserved -> TRIGGERS (fails assertion).
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_win_2 = {
+        "fallback_value": "AUTO",
+        "threshold": 3,
+        "window_seconds": 2.0,
+        "prune_values": [],
+    }
+    with patch("time.monotonic", side_effect=[10.0, 10.8, 11.6, 12.4]):
+        for val in ["1", "2", "1", "2"]:
+            conn._evaluate_oscillation_rule("FANSP", val, rule_win_2)
+    assert not spy_loop_break.called
+
+    # Case B: window_seconds=4.0 with span 3.5s (10.0 -> 13.5).
+    # Original: span 3.5s <= 4.0s -> 4 items preserved -> TRIGGERS.
+    # Mutants (using default 3.0s): span 3.5s > 3.0s -> first item purged, 3 items < 4 -> does NOT trigger (fails assertion).
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_win_4 = {
+        "fallback_value": "AUTO",
+        "threshold": 3,
+        "window_seconds": 4.0,
+        "prune_values": [],
+    }
+    with patch("time.monotonic", side_effect=[10.0, 10.9, 11.8, 13.5]):
+        for val in ["1", "2", "1", "2"]:
+            conn._evaluate_oscillation_rule("FANSP", val, rule_win_4)
+    assert spy_loop_break.called
+
+    # Case C: Rule WITHOUT window_seconds key, testing exact default 3.0s boundary (kills L426 Mutant 28: default 3.0 -> 4.0).
+    # Updates span 3.5s (10.0 -> 13.5).
+    # Original (default 3.0s): span 3.5s > 3.0s -> first item purged, 3 items < 4 -> does NOT trigger.
+    # Mutant 28 (default 4.0s): span 3.5s <= 4.0s -> all 4 items preserved -> TRIGGERS (fails assertion).
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_default_win = {"fallback_value": "AUTO", "threshold": 3, "prune_values": []}
+    with patch("time.monotonic", side_effect=[10.0, 10.9, 11.8, 13.5]):
+        for val in ["1", "2", "1", "2"]:
+            conn._evaluate_oscillation_rule("FANSP", val, rule_default_win)
+    assert not spy_loop_break.called
+
+    # 4. Prune values matching (kills L423 list comp, L427 PRUNE_VALUES case, and L442 prune_matches = None)
+    # Uses fallback_value="AUTO" which is NOT one of the oscillating values ("PRUNE_ME", "OTHER_VAL").
+    # Ending on "OTHER_VAL":
+    # - Original: detects prune_matches=["PRUNE_ME"], bad_val="PRUNE_ME", fallback="AUTO".
+    # - Mutant 36 (PRUNE_VALUES): prune_values is empty, fallback not in values, falls to else -> bad_val="OTHER_VAL".
+    # - Mutant 50 (prune_matches=None): falls to else -> bad_val="OTHER_VAL".
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_prune = {
+        "fallback_value": "AUTO",
+        "threshold": 3,
+        "window_seconds": 3.0,
+        "prune_values": ["PRUNE_ME"],
+    }
+    for val in ["PRUNE_ME", "OTHER_VAL", "PRUNE_ME", "OTHER_VAL"]:
+        conn._evaluate_oscillation_rule("FANSP", val, rule_prune)
+    spy_loop_break.assert_called_with("FANSP", "PRUNE_ME", "AUTO", rule_prune)
+
+    # 5. Fallback matching bad_val selection (kills L443 if v != fallback_val mutant '==')
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_fb = {
+        "fallback_value": "FB_VAL",
+        "threshold": 3,
+        "window_seconds": 3.0,
+        "prune_values": [],
+    }
+    for val in ["FB_VAL", "BAD_VAL", "FB_VAL", "BAD_VAL"]:
+        conn._evaluate_oscillation_rule("FANSP", val, rule_fb)
+    spy_loop_break.assert_called_with("FANSP", "BAD_VAL", "FB_VAL", rule_fb)
+
+    # 6. Else branch: bad_val = active_hist[-1][1] vs [+1] (kills L446)
+    # With threshold=4 and 5 updates: ["A", "B", "A", "B", "A"]:
+    # Update 4 ("B") has 3 alternations (<4, does not trigger).
+    # Update 5 ("A") has 4 alternations (>=4, triggers).
+    # active_hist[-1] is "A", while mutant active_hist[+1] is "B".
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_else = {
+        "fallback_value": "NEITHER",
+        "threshold": 4,
+        "window_seconds": 3.0,
+        "prune_values": [],
+    }
+    for val in ["A", "B", "A", "B", "A"]:
+        conn._evaluate_oscillation_rule("FANSP", val, rule_else)
+    spy_loop_break.assert_called_with("FANSP", "A", "NEITHER", rule_else)
+
+    # 7. Alternations range boundary (kills L451 range(1, len) vs range(len))
+    # 4 updates with threshold=4 has 3 alternations. range(len) wraps around and counts 4
+    spy_loop_break.reset_mock()
+    conn._node_history.clear()
+    rule_range = {
+        "fallback_value": "NEITHER",
+        "threshold": 4,
+        "window_seconds": 3.0,
+        "prune_values": [],
+    }
+    for val in ["A", "B", "A", "B"]:
+        conn._evaluate_oscillation_rule("FANSP", val, rule_range)
+    assert not spy_loop_break.called
+
+
+@pytest.mark.asyncio
+async def test_intesisbox_loop_breaker_hass_attribute_fallback() -> None:
+    """Kill L465 and L527 (if self._hass and hasattr(...) mutants) when hass lacks async_create_task."""
+    conn = ConnectionIntesisBox(
+        config={CONF_IP_ADDRESS: "127.0.0.1", CONF_PORT: 3310},
+        logger=_LOGGER,
+    )
+    # Set _hass to a non-None object that does NOT have async_create_task
+    # Mutants mutating 'and' to 'or' will try to access self._hass.async_create_task and fail
+    conn._hass = object()
+
+    rule = {
+        "node": "FANSP",
+        "fallback_value": "AUTO",
+        "fallback_command": "SET,1:FANSP,AUTO",
+        "prune_values": [],
+        "threshold": 3,
+        "window_seconds": 3.0,
+    }
+    conn._send_raw = AsyncMock()
+
+    # 1. Test _evaluate_oscillation_rule with non-HA hass (kills L465)
+    with patch("asyncio.create_task") as mock_task:
+        for val in ["MANUAL", "AUTO", "MANUAL", "AUTO"]:
+            conn._evaluate_oscillation_rule("FANSP", val, rule)
+        mock_task.assert_called_once()
+
+    # 2. Test _async_execute_loop_break with non-HA hass and coroutine callback (kills L527)
+    async def async_cb(payload: dict[str, Any]) -> None:
+        pass
+
+    conn._update_callback = async_cb
+
+    with patch("asyncio.create_task") as mock_task:
+        await conn._async_execute_loop_break("FANSP", "MANUAL", "AUTO", rule)
+        mock_task.assert_called_once()
+
+
+
+
+
+
 
 
 

--- a/tests/test_controller_yaml.py
+++ b/tests/test_controller_yaml.py
@@ -291,6 +291,7 @@ def mock_yaml_controller():
         controller.loader.properties = {}
         controller.loader.sensors = {}
         controller.loader.name = None
+        controller.poller._last_icmp_diagnostic = None
         controller._attributes = {}
 
         return controller
@@ -635,6 +636,7 @@ def test_yaml_controller_last_poll_data(mock_yaml_controller) -> None:
 def test_yaml_controller_connection_diagnostics(mock_yaml_controller) -> None:
     """Kills mutants in connection_diagnostics."""
     mock_yaml_controller.loader.connection = None
+    mock_yaml_controller.poller._last_icmp_diagnostic = None
     assert mock_yaml_controller.connection_diagnostics == {}
 
     mock_conn = MagicMock()
@@ -643,6 +645,21 @@ def test_yaml_controller_connection_diagnostics(mock_yaml_controller) -> None:
     assert mock_yaml_controller.connection_diagnostics == {
         "latency_ms": 12,
         "connected": True,
+    }
+
+    mock_yaml_controller.poller._last_icmp_diagnostic = {
+        "is_reachable": True,
+        "avg_rtt_ms": 1.5,
+        "status": "alive",
+    }
+    assert mock_yaml_controller.connection_diagnostics == {
+        "latency_ms": 12,
+        "connected": True,
+        "network_reachability": {
+            "is_reachable": True,
+            "avg_rtt_ms": 1.5,
+            "status": "alive",
+        },
     }
 
 

--- a/tests/test_controller_yaml_polling__snniper.py
+++ b/tests/test_controller_yaml_polling__snniper.py
@@ -711,3 +711,24 @@ async def test_sniper_prediction_forensic_logging_guards_m6_m81_m82():
             "[Forensic] Prediction ended" in str(c.args[0])
             for c in mock_debug.call_args_list
         ), "Mutant M82 survived: Prediction ended NOT logged when pending is empty but corrections exists"
+
+
+async def test_async_update_properties_backup_native_injection():
+    """Kill mutant on L1010 of controller_yaml_polling.py: 'if val is not None:' mutated to 'if val is None:'."""
+    ctrl = DummyController()
+    poller = YamlStatePoller(ctrl)
+    poller._predict_dependency_cascades = MagicMock(return_value={})
+    poller._inject_value_into_state = MagicMock()
+    dummy_prop = NakedObj(id="target_temperature", value=20)
+    ctrl.loader.properties = {"target_temperature": dummy_prop}
+    poller._pending_updates = {"target_temperature": (24, time.monotonic())}
+
+    await poller.async_update_properties_from_state(
+        {"Devices": [{}]}, is_prediction=False, force_update=True
+    )
+
+    # Mutant changed 'if val is not None' to 'if val is None', which bypasses backup native injection
+    assert poller._inject_value_into_state.call_count == 2
+    assert poller._inject_value_into_state.call_args_list[1][0][0] == dummy_prop
+    assert poller._inject_value_into_state.call_args_list[1][0][2] == 24
+

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -598,6 +598,7 @@ async def test_diagnostics_top_level_keys(mock_hass):
     assert "raw_device_state" in res
     assert "bootstrapping" in res
     assert "entry" in res
+    assert "network_diagnostics" in res
     assert res["bootstrapping"]["total_devices_discovered"] == 0
     assert res["bootstrapping"]["skipped_devices_missing_info"] == 0
 
@@ -834,3 +835,230 @@ def test_deep_redact_substrings_multiple_occurrences() -> None:
     payload = {"key": "this is a secret and another secret"}
     redacted = _deep_redact_substrings(payload, threat_patterns)
     assert redacted == {"key": "this is a **REDACTED** and another **REDACTED**"}
+
+
+async def test_diagnostics_network_diagnostics_structure(mock_hass, mock_entry):
+    """Test network_diagnostics structure including active_probe and last_runtime_check."""
+    mock_coord = MagicMock(spec=SamsungClimateCoordinator)
+    mock_coord.data = None
+    mock_coord.devices = {}
+    mock_coord.controller = MagicMock()
+    mock_coord.controller.connection_diagnostics = {
+        "network_reachability": {
+            "is_reachable": True,
+            "avg_rtt_ms": 2.5,
+            "status": "alive",
+            "privileged_mode": False,
+        }
+    }
+    mock_entry.runtime_data = mock_coord
+
+    res = await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+
+    assert "network_diagnostics" in res
+    net_diag = res["network_diagnostics"]
+    assert "privileged_probe_support" in net_diag
+    assert isinstance(net_diag["privileged_probe_support"], bool)
+    assert net_diag["last_runtime_check"] == {
+        "is_reachable": True,
+        "avg_rtt_ms": 2.5,
+        "status": "alive",
+        "privileged_mode": False,
+    }
+    assert net_diag["active_probe"]["is_reachable"] is True
+    assert net_diag["active_probe"]["status"] == "alive"
+
+
+async def test_diagnostics_network_diagnostics_no_host(mock_hass):
+    """Test network_diagnostics when no host or IP address is configured."""
+    entry = MagicMock()
+    entry.entry_id = "test_no_host"
+    entry.data = {}
+    entry.options = {}
+    entry.title = "No Host AC"
+    entry.domain = DOMAIN
+    entry.unique_id = "uid_no_host"
+
+    mock_coord = MagicMock(spec=SamsungClimateCoordinator)
+    mock_coord.data = None
+    mock_coord.devices = {}
+    mock_coord.controller = MagicMock(spec=[])
+    entry.runtime_data = mock_coord
+
+    res = await async_get_config_entry_diagnostics(mock_hass, entry)
+
+    assert "network_diagnostics" in res
+    net_diag = res["network_diagnostics"]
+    assert net_diag["active_probe"] == {
+        "is_reachable": None,
+        "status": "no_host_configured",
+    }
+    assert net_diag["last_runtime_check"] == {
+        "is_reachable": None,
+        "status": "not_recorded",
+    }
+
+
+async def test_diagnostics_network_diagnostics_multi_coordinator(mock_hass, mock_entry):
+    """Test network_diagnostics with multi-coordinator dictionary setup."""
+    coord1 = MagicMock(spec=SamsungClimateCoordinator)
+    coord1.data = None
+    coord1.devices = {}
+    coord1.controller = MagicMock()
+    coord1.controller.connection_diagnostics = {
+        "network_reachability": {
+            "is_reachable": False,
+            "avg_rtt_ms": None,
+            "status": "dead",
+        }
+    }
+
+    mock_entry.runtime_data = {"sub_unit_1": coord1}
+
+    res = await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+
+    assert "network_diagnostics" in res
+    net_diag = res["network_diagnostics"]
+    assert net_diag["last_runtime_check"] == {
+        "is_reachable": False,
+        "avg_rtt_ms": None,
+        "status": "dead",
+    }
+
+
+async def test_diagnostics_network_diagnostics_fallback_to_global_registry(
+    mock_hass, mock_entry
+):
+    """Test fallback to get_last_network_diagnostic when controller has no network_reachability."""
+    from unittest.mock import patch
+
+    mock_coord = MagicMock(spec=SamsungClimateCoordinator)
+    mock_coord.data = None
+    mock_coord.devices = {}
+    mock_coord.controller = MagicMock(spec=[])
+    mock_entry.runtime_data = mock_coord
+
+    recorded_diag = {
+        "is_reachable": True,
+        "avg_rtt_ms": 3.1,
+        "status": "alive",
+        "privileged_mode": False,
+    }
+
+    with patch(
+        "custom_components.climate_ip.diagnostics.get_last_network_diagnostic",
+        return_value=recorded_diag,
+    ):
+        res = await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+
+    assert "network_diagnostics" in res
+    assert res["network_diagnostics"]["last_runtime_check"] == recorded_diag
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_target_host_resolution_hierarchy(mock_hass, mock_entry):
+    """Kill L291, L293, L296-297, L301-311, and L331-332 mutants in diagnostics.py.
+
+    Tests target_host resolution across all possible config, option, coordinator, and
+    multi-coordinator sources, ensuring exact ping_timeout=1.0 forwarding.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    mock_probe = AsyncMock(return_value={"is_reachable": True, "status": "alive"})
+
+    with patch(
+        "custom_components.climate_ip.diagnostics.async_get_network_diagnostics",
+        mock_probe,
+    ):
+        # 1. Host in entry.data['host']
+        mock_entry.data = {"host": "10.0.0.1"}
+        mock_entry.options = {}
+        mock_entry.runtime_data = None
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.1", ping_timeout=1.0)
+
+        # 2. Host in entry.data['ip_address'] (no 'host')
+        mock_entry.data = {"ip_address": "10.0.0.2"}
+        mock_entry.options = {}
+        mock_entry.runtime_data = None
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.2", ping_timeout=1.0)
+
+        # 3. Host in entry.options['host']
+        mock_entry.data = {}
+        mock_entry.options = {"host": "10.0.0.3"}
+        mock_entry.runtime_data = None
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.3", ping_timeout=1.0)
+
+        # 4. Host in entry.options['ip_address']
+        mock_entry.data = {}
+        mock_entry.options = {"ip_address": "10.0.0.4"}
+        mock_entry.runtime_data = None
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.4", ping_timeout=1.0)
+
+        # 5. Host in single coordinator controller.ip_address
+        mock_entry.data = {}
+        mock_entry.options = {}
+        single_coord = MagicMock(spec=SamsungClimateCoordinator)
+        single_coord.data = None
+        single_coord.devices = {}
+        single_coord.controller = MagicMock()
+        single_coord.controller.ip_address = "10.0.0.5"
+        single_coord.controller.host = None
+        single_coord.controller._cfg = None
+        single_coord.controller.connection_diagnostics = {}
+        mock_entry.runtime_data = single_coord
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.5", ping_timeout=1.0)
+
+        # 6. Host in single coordinator controller.host
+        single_coord.controller.ip_address = None
+        single_coord.controller.host = "10.0.0.6"
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.6", ping_timeout=1.0)
+
+        # 7. Host in single coordinator controller._cfg.host
+        single_coord.controller.ip_address = None
+        single_coord.controller.host = None
+        single_coord.controller._cfg = MagicMock()
+        single_coord.controller._cfg.host = "10.0.0.7"
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.7", ping_timeout=1.0)
+
+        # 8. Host in multi-coordinator dictionary (MIM-H03 indoor units) -> kills L301-311
+        multi_coord = MagicMock(spec=SamsungClimateCoordinator)
+        multi_coord.data = None
+        multi_coord.devices = {}
+        multi_coord.controller = MagicMock()
+        multi_coord.controller.ip_address = "10.0.0.8"
+        multi_coord.controller.connection_diagnostics = {}
+        mock_entry.runtime_data = {"indoor_1": multi_coord}
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.8", ping_timeout=1.0)
+
+        # Multi-coordinator with controller.host
+        multi_coord.controller.ip_address = None
+        multi_coord.controller.host = "10.0.0.9"
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.9", ping_timeout=1.0)
+
+        # Multi-coordinator with controller._cfg.host
+        multi_coord.controller.ip_address = None
+        multi_coord.controller.host = None
+        multi_coord.controller._cfg = MagicMock()
+        multi_coord.controller._cfg.host = "10.0.0.10"
+        await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        mock_probe.assert_called_with("10.0.0.10", ping_timeout=1.0)
+
+        # 9. No host configured at all
+        mock_entry.data = {}
+        mock_entry.options = {}
+        mock_entry.runtime_data = None
+        res_no_host = await async_get_config_entry_diagnostics(mock_hass, mock_entry)
+        assert res_no_host["network_diagnostics"]["active_probe"] == {
+            "is_reachable": None,
+            "status": "no_host_configured",
+        }
+

--- a/tests/test_helpers__advanced.py
+++ b/tests/test_helpers__advanced.py
@@ -14,12 +14,15 @@ import pytest
 
 from custom_components.climate_ip.helpers import (
     ICMPSocketError,
+    _can_use_icmp_privileged,
     async_check_network_reachability,
     async_create_samsung_ssl_context,
     async_get_mac_address,
+    async_get_network_diagnostics,
     create_samsung_ssl_context,
     find_key_in_data,
     format_placeholders,
+    get_last_network_diagnostic,
     get_tls_version_name,
     get_value_by_path,
     mask_sensitive_data,
@@ -609,8 +612,9 @@ def test_mask_sensitive_data_strings():
 
 # --- async_check_network_reachability (Updated) ---
 @pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
 @patch("custom_components.climate_ip.helpers.async_ping")
-async def test_async_check_network_reachability(mock_ping):
+async def test_async_check_network_reachability(mock_ping, mock_can_use):
     mock_host = MagicMock()
     mock_host.is_alive = True
     mock_host.avg_rtt = 10
@@ -697,6 +701,62 @@ async def test_async_check_network_reachability_no_library():
     finally:
         # Restore module to original state so we don't break other tests
         helpers_module.async_ping = original_ping
+
+
+@pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=True)
+@patch("custom_components.climate_ip.helpers.async_ping")
+async def test_async_check_network_reachability_privileged_true(mock_ping, mock_can_use):
+    """Verify that when _can_use_icmp_privileged returns True, async_ping receives privileged=True."""
+    mock_host = MagicMock()
+    mock_host.is_alive = True
+    mock_ping.return_value = mock_host
+
+    result = await async_check_network_reachability("192.168.1.100")
+    assert result is True
+    assert mock_ping.call_args.kwargs["privileged"] is True
+
+
+@pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
+@patch("custom_components.climate_ip.helpers.async_ping")
+async def test_async_check_network_reachability_privileged_false(mock_ping, mock_can_use):
+    """Verify that when _can_use_icmp_privileged returns False, async_ping receives privileged=False."""
+    mock_host = MagicMock()
+    mock_host.is_alive = True
+    mock_ping.return_value = mock_host
+
+    result = await async_check_network_reachability("192.168.1.100")
+    assert result is True
+    assert mock_ping.call_args.kwargs["privileged"] is False
+
+
+def test_can_use_icmp_privileged_probe():
+    """Verify cached dynamic ICMP privilege probe behavior and fallbacks."""
+    import custom_components.climate_ip.helpers as helpers_mod
+
+    # 1. When _ICMPLIB_AVAILABLE is False -> False
+    with patch.object(helpers_mod, "_ICMPLIB_AVAILABLE", False):
+        _can_use_icmp_privileged.cache_clear()
+        assert _can_use_icmp_privileged() is False
+
+    # 2. When ping succeeds with privileged=True -> True
+    with patch("icmplib.ping", return_value=MagicMock()) as mock_ping_sync:
+        _can_use_icmp_privileged.cache_clear()
+        assert _can_use_icmp_privileged() is True
+        mock_ping_sync.assert_called_once_with(
+            "127.0.0.1", count=0, timeout=0, privileged=True
+        )
+
+    # 3. When ping raises Exception (e.g. SocketPermissionError) -> False
+    with patch("icmplib.ping", side_effect=Exception("Root privileges required")):
+        _can_use_icmp_privileged.cache_clear()
+        assert _can_use_icmp_privileged() is False
+
+    # Seed the cache with False so unmocked calls don't hit socket.socket
+    _can_use_icmp_privileged.cache_clear()
+    with patch("icmplib.ping", side_effect=Exception("Root privileges required")):
+        _can_use_icmp_privileged()
 
 
 def test_safe_xml_to_dict_non_string_mutation():
@@ -1078,9 +1138,10 @@ async def test_async_get_mac_address_token_filtering_and_loop_resilience(mock_ex
         ("https://[2001:db8::3]:443/status", "2001:db8::3", False),
     ],
 )
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
 @patch("custom_components.climate_ip.helpers.async_ping")
 async def test_x_async_check_network_reachability_matrix(
-    mock_ping, input_host, expected_ip, is_bypass
+    mock_ping, mock_priv, input_host, expected_ip, is_bypass
 ):
     """Sniper matrix for async_check_network_reachability to eradicate string slicing mutants."""
     mock_host = MagicMock()
@@ -1107,8 +1168,9 @@ async def test_x_async_check_network_reachability_matrix(
 
 
 @pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
 @patch("custom_components.climate_ip.helpers.async_ping")
-async def test_async_check_network_reachability_string_slicing_survivors(mock_ping):
+async def test_async_check_network_reachability_string_slicing_survivors(mock_ping, mock_priv):
     """Kills any remaining mutants on lines 546, 553, 554 in async_check_network_reachability."""
     mock_host = MagicMock()
     mock_host.is_alive = True
@@ -1197,3 +1259,292 @@ async def test_async_check_network_reachability_string_slicing_survivors(mock_pi
     assert isinstance(mock_ping.call_args.kwargs["timeout"], float)
     assert isinstance(mock_ping.call_args.kwargs["interval"], float)
     assert isinstance(mock_ping.call_args.kwargs["privileged"], bool)
+
+
+@pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
+@patch("custom_components.climate_ip.helpers.async_ping")
+async def test_async_get_network_diagnostics_success(mock_ping, mock_priv):
+    """Test async_get_network_diagnostics when host is alive."""
+    mock_host = MagicMock()
+    mock_host.is_alive = True
+    mock_host.avg_rtt = 12.34
+    mock_ping.return_value = mock_host
+
+    diag = await async_get_network_diagnostics("http://192.168.1.100:8888")
+    assert diag["is_reachable"] is True
+    assert diag["avg_rtt_ms"] == 12.34
+    assert diag["status"] == "alive"
+    assert diag["privileged_mode"] is False
+    assert "timestamp" in diag
+
+    # Verify cached in get_last_network_diagnostic
+    last = get_last_network_diagnostic("192.168.1.100")
+    assert last is not None
+    assert last["status"] == "alive"
+
+
+@pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
+@patch("custom_components.climate_ip.helpers.async_ping")
+async def test_async_get_network_diagnostics_unreachable(mock_ping, mock_priv):
+    """Test async_get_network_diagnostics when ping times out."""
+    mock_host = MagicMock()
+    mock_host.is_alive = False
+    mock_ping.return_value = mock_host
+
+    diag = await async_get_network_diagnostics("192.168.1.101")
+    assert diag["is_reachable"] is False
+    assert diag["avg_rtt_ms"] is None
+    assert diag["status"] == "unreachable_timeout"
+
+
+@pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
+@patch("custom_components.climate_ip.helpers.async_ping")
+async def test_async_get_network_diagnostics_permission_bypassed(mock_ping, mock_priv):
+    """Test async_get_network_diagnostics on SocketPermissionError and OSError."""
+    from icmplib import SocketPermissionError
+
+    mock_ping.side_effect = SocketPermissionError(privileged=False)
+    diag = await async_get_network_diagnostics("192.168.1.102")
+    assert diag["is_reachable"] is True
+    assert diag["status"] == "permission_bypassed"
+
+    mock_ping.side_effect = OSError("Permission denied")
+    diag_os = await async_get_network_diagnostics("192.168.1.102")
+    assert diag_os["is_reachable"] is True
+    assert diag_os["status"] == "permission_bypassed"
+
+
+@pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
+@patch("custom_components.climate_ip.helpers.async_ping")
+async def test_async_get_network_diagnostics_errors(mock_ping, mock_priv):
+    """Test async_get_network_diagnostics on DNS and socket errors."""
+    from icmplib import ICMPSocketError, NameLookupError
+
+    mock_ping.side_effect = NameLookupError("Unknown host")
+    diag_dns = await async_get_network_diagnostics("unknown.device.lan")
+    assert diag_dns["is_reachable"] is False
+    assert diag_dns["status"] == "dns_error"
+
+    mock_ping.side_effect = ICMPSocketError("Socket closed")
+    diag_sock = await async_get_network_diagnostics("192.168.1.103")
+    assert diag_sock["is_reachable"] is False
+    assert diag_sock["status"] == "socket_error"
+
+    mock_ping.side_effect = RuntimeError("Unexpected")
+    diag_err = await async_get_network_diagnostics("192.168.1.104")
+    assert diag_err["is_reachable"] is False
+    assert diag_err["status"] == "error_RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_async_get_network_diagnostics_bypasses():
+    """Test async_get_network_diagnostics loopback, missing host, and missing library."""
+    # 1. Missing / invalid host
+    diag_none = await async_get_network_diagnostics("")
+    assert diag_none["is_reachable"] is False
+    assert diag_none["status"] == "missing_host"
+
+    diag_invalid = await async_get_network_diagnostics(12345)  # type: ignore[arg-type]
+    assert diag_invalid["is_reachable"] is False
+    assert diag_invalid["status"] == "missing_host"
+
+    # 2. Loopback bypass
+    diag_loop = await async_get_network_diagnostics("http://127.0.0.1:8888")
+    assert diag_loop["is_reachable"] is True
+    assert diag_loop["status"] == "loopback_bypass"
+
+    # 3. Missing library
+    import custom_components.climate_ip.helpers as helpers_mod
+
+    orig_ping = helpers_mod.async_ping
+    helpers_mod.async_ping = None
+    try:
+        diag_no_lib = await async_get_network_diagnostics("192.168.1.105")
+        assert diag_no_lib["is_reachable"] is True
+        assert diag_no_lib["status"] == "library_missing"
+    finally:
+        helpers_mod.async_ping = orig_ping
+
+    # 4. get_last_network_diagnostic with None
+    assert get_last_network_diagnostic(None) is None
+    assert get_last_network_diagnostic("") is None
+
+
+@pytest.mark.asyncio
+async def test_get_last_network_diagnostic_parsing_and_types():
+    """Kill L563, L565, L567-569, and L572-573 mutants in get_last_network_diagnostic."""
+    from custom_components.climate_ip.helpers import _LAST_NETWORK_DIAGNOSTICS
+
+    # 1. Non-string and empty inputs (kills L563 mutants)
+    assert get_last_network_diagnostic(12345) is None  # type: ignore[arg-type]
+    assert get_last_network_diagnostic([1, 2, 3]) is None  # type: ignore[arg-type]
+
+    # 2. Host parsing: schemes, paths, ports, and IPv6
+    diag_data = {"is_reachable": True, "status": "alive"}
+
+    _LAST_NETWORK_DIAGNOSTICS["192.168.1.50"] = dict(diag_data)
+    _LAST_NETWORK_DIAGNOSTICS["fe80::1"] = dict(diag_data)
+    _LAST_NETWORK_DIAGNOSTICS["fe80:1"] = dict(diag_data)
+    _LAST_NETWORK_DIAGNOSTICS["192.168.1.50]"] = dict(diag_data)
+    _LAST_NETWORK_DIAGNOSTICS["[192.168.1.50"] = dict(diag_data)
+
+    # IPv4 with URL scheme and path (kills L565)
+    assert get_last_network_diagnostic("http://192.168.1.50/api/v1") == diag_data
+    # IPv4 with path but no port (kills split without '/')
+    assert get_last_network_diagnostic("http://192.168.1.50/status") == diag_data
+    # IPv4 with port (kills L567-568)
+    assert get_last_network_diagnostic("192.168.1.50:2878") == diag_data
+    # Bracketed IPv6 with port (kills L572-573)
+    assert get_last_network_diagnostic("[fe80::1]:8080") == diag_data
+    # Bracketed IPv6 with single colon (kills L567-569 and L572-573 or-mutation)
+    assert get_last_network_diagnostic("[fe80:1]") == diag_data
+    # Unmatched brackets: closing only (kills startswith or ']' in clean_host)
+    assert get_last_network_diagnostic("192.168.1.50]") == diag_data
+    # Unmatched brackets: opening only (kills startswith or ']' in clean_host)
+    assert get_last_network_diagnostic("[192.168.1.50") == diag_data
+    # Raw unbracketed IPv6 with multiple colons (kills L568-569 untested mutant 25)
+    assert get_last_network_diagnostic("fe80::1") == diag_data
+
+
+@pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=True)
+@patch("custom_components.climate_ip.helpers.async_ping")
+async def test_async_get_network_diagnostics_strict_args_and_clean_host(
+    mock_ping, mock_priv
+):
+    """Kill L698, L710, L715-723, L730, and L741-747 mutants in async_get_network_diagnostics."""
+    import custom_components.climate_ip.helpers as helpers_mod
+
+    mock_host_obj = MagicMock()
+    mock_host_obj.is_alive = True
+    mock_host_obj.avg_rtt = 2.45
+    mock_ping.return_value = mock_host_obj
+
+    # 1. Test exact kwargs passed to async_ping (kills L741-747)
+    diag = await async_get_network_diagnostics("192.168.1.100", ping_timeout=2.5)
+    mock_ping.assert_called_with(
+        address="192.168.1.100",
+        count=1,
+        timeout=2.5,
+        interval=0.2,
+        privileged=True,
+    )
+    assert diag["is_reachable"] is True
+    assert diag["avg_rtt_ms"] == 2.45
+    assert diag["privileged_mode"] is True
+
+    # 2. Test URL with scheme, port, and path cleaning (kills L715, L717, L722-723)
+    await async_get_network_diagnostics("http://192.168.1.101:8080/status", ping_timeout=1.0)
+    mock_ping.assert_called_with(
+        address="192.168.1.101",
+        count=1,
+        timeout=1.0,
+        interval=0.2,
+        privileged=True,
+    )
+
+    # URL with path but no port (kills split without '/')
+    await async_get_network_diagnostics("http://192.168.1.101/status", ping_timeout=1.0)
+    mock_ping.assert_called_with(
+        address="192.168.1.101",
+        count=1,
+        timeout=1.0,
+        interval=0.2,
+        privileged=True,
+    )
+
+    # Bracketed IPv6 cleaning
+    await async_get_network_diagnostics("[fe80::2]:8888", ping_timeout=1.0)
+    mock_ping.assert_called_with(
+        address="fe80::2",
+        count=1,
+        timeout=1.0,
+        interval=0.2,
+        privileged=True,
+    )
+
+    # Bracketed IPv6 with single colon (kills L717 or-mutation)
+    await async_get_network_diagnostics("[fe80:1]", ping_timeout=1.0)
+    mock_ping.assert_called_with(
+        address="fe80:1",
+        count=1,
+        timeout=1.0,
+        interval=0.2,
+        privileged=True,
+    )
+
+    # Unmatched brackets: closing only (kills L722 startswith or ']' in clean_host)
+    await async_get_network_diagnostics("192.168.1.50]", ping_timeout=1.0)
+    mock_ping.assert_called_with(
+        address="192.168.1.50]",
+        count=1,
+        timeout=1.0,
+        interval=0.2,
+        privileged=True,
+    )
+
+    # Unmatched brackets: opening only (kills L722 startswith or ']' in clean_host)
+    await async_get_network_diagnostics("[192.168.1.50", ping_timeout=1.0)
+    mock_ping.assert_called_with(
+        address="[192.168.1.50",
+        count=1,
+        timeout=1.0,
+        interval=0.2,
+        privileged=True,
+    )
+
+    # 3. Test privileged_mode is strictly False on bypasses (kills L698, L710, L730)
+    # Missing host (L698)
+    res_none = await async_get_network_diagnostics(None)  # type: ignore[arg-type]
+    assert res_none["privileged_mode"] is False
+
+    # Library missing (L710)
+    orig_ping = helpers_mod.async_ping
+    helpers_mod.async_ping = None
+    try:
+        res_no_lib = await async_get_network_diagnostics("192.168.1.102")
+        assert res_no_lib["privileged_mode"] is False
+    finally:
+        helpers_mod.async_ping = orig_ping
+
+    # Loopback bypass (L730)
+    res_loop = await async_get_network_diagnostics("127.0.0.1")
+    assert res_loop["privileged_mode"] is False
+    assert res_loop["status"] == "loopback_bypass"
+
+
+@pytest.mark.asyncio
+@patch("custom_components.climate_ip.helpers._can_use_icmp_privileged", return_value=False)
+@patch("custom_components.climate_ip.helpers.async_ping")
+async def test_async_check_network_reachability_strict_diagnostics_recording(
+    mock_ping, mock_priv
+):
+    """Kill L616-617 and L662-663 mutants in async_check_network_reachability."""
+    from custom_components.climate_ip.helpers import ICMPSocketError
+
+    # 1. Host is alive (kills L616-617)
+    mock_alive = MagicMock()
+    mock_alive.is_alive = True
+    mock_alive.avg_rtt = 1.1
+    mock_ping.return_value = mock_alive
+
+    ok = await async_check_network_reachability("192.168.1.200")
+    assert ok is True
+    rec_alive = get_last_network_diagnostic("192.168.1.200")
+    assert rec_alive is not None
+    assert rec_alive["is_reachable"] is True
+    assert rec_alive["status"] == "alive"
+
+    # 2. ICMPSocketError (kills L662-663)
+    mock_ping.side_effect = ICMPSocketError("Socket fail")
+    fail = await async_check_network_reachability("192.168.1.201")
+    assert fail is False
+    rec_fail = get_last_network_diagnostic("192.168.1.201")
+    assert rec_fail is not None
+    assert rec_fail["is_reachable"] is False
+    assert rec_fail["status"] == "socket_error"
+

--- a/tests/test_samsung_2878__critical_survivors.py
+++ b/tests/test_samsung_2878__critical_survivors.py
@@ -280,3 +280,24 @@ async def test_read_full_response_reader_none(connection):
     connection._reader = None
     res = await connection._read_full_response()
     assert res is None
+
+
+def test_get_diagnostics_network_reachability_strict(connection):
+    """Kill mutants in ConnectionSamsung2878.get_diagnostics for network_reachability."""
+    # 1. When _last_icmp_diagnostic is None: must return default dict, not None
+    connection._last_icmp_diagnostic = None
+    diag1 = connection.get_diagnostics()
+    assert "network_reachability" in diag1
+    assert diag1["network_reachability"] == {
+        "is_reachable": None,
+        "status": "not_checked_yet",
+    }
+    assert diag1["network_reachability"] is not None
+
+    # 2. When _last_icmp_diagnostic is populated: must be preserved exactly
+    custom_diag = {"is_reachable": True, "avg_rtt_ms": 1.23, "status": "alive"}
+    connection._last_icmp_diagnostic = custom_diag
+    diag2 = connection.get_diagnostics()
+    assert diag2["network_reachability"] == custom_diag
+    assert diag2["network_reachability"] is not None
+

--- a/tests/test_token_acquirer_yaml__stream.py
+++ b/tests/test_token_acquirer_yaml__stream.py
@@ -953,3 +953,153 @@ async def test_wait_for_token_stream_missing_extract_template(mock_hass, stream_
     ):
         with pytest.raises(TypeError):
             await acq.async_wait_for_token()
+
+
+async def test_wait_for_token_stream_extracts_from_initial_stream_data(
+    mock_hass, stream_config
+):
+    """Kill mutants on L396-402: regex extraction from _initial_stream_data."""
+    stream_config["extract_template"] = {"regex": r"DeviceToken:\s*([a-zA-Z0-9_-]+)"}
+    acq = GenericYamlTokenAcquirer(
+        mock_hass, "192.168.1.100", stream_config, cert_path=None
+    )
+    acq._reader = AsyncMock()
+    acq._initial_stream_data = "Banner hello DeviceToken: SECRET_TOKEN_1234 trailing"
+
+    token = await acq.async_wait_for_token()
+    assert token == "SECRET_TOKEN_1234"
+    acq._reader.read.assert_not_called()
+
+
+async def test_connect_stream_plain_tcp_explicit_enabled_false(mock_hass, stream_config):
+    """Kill mutants on L193, L196, L198, L199, L206, L207, L208, L212 for plain TCP stream."""
+    stream_config["tls_config"] = {"enabled": False, "strategies": []}
+    stream_config["request_pairing"] = {"port": 3310}
+    stream_config["buffer_size"] = 2048
+
+    acq = GenericYamlTokenAcquirer(
+        mock_hass, "192.168.1.100", stream_config, cert_path=None
+    )
+    mock_reader = AsyncMock()
+    mock_writer = AsyncMock()
+    mock_reader.read.return_value = b"BannerData"
+
+    with patch(
+        "asyncio.open_connection", return_value=(mock_reader, mock_writer)
+    ) as mock_open:
+        with patch(
+            "custom_components.climate_ip.token_acquirer_yaml.asyncio.timeout",
+            side_effect=asyncio.timeout,
+        ) as mock_timeout:
+            res = await acq._connect_stream()
+
+    assert res == {"plain_tcp": True}
+    assert res["plain_tcp"] is True
+    mock_open.assert_called_once_with("192.168.1.100", 3310, ssl=None)
+    assert acq._reader is mock_reader
+    assert acq._writer is mock_writer
+    mock_reader.read.assert_called_once_with(2048)
+    assert any(c.args == (15.0,) for c in mock_timeout.call_args_list)
+    assert any(c.args == (1.0,) for c in mock_timeout.call_args_list)
+
+
+async def test_connect_stream_plain_tcp_method_tcp(mock_hass, stream_config):
+    """Kill mutant on L196: req_cfg method == 'tcp' condition."""
+    stream_config["tls_config"] = {"enabled": True, "strategies": []}
+    stream_config["request_pairing"] = {"method": "tcp", "port": 2878}
+
+    acq = GenericYamlTokenAcquirer(
+        mock_hass, "192.168.1.100", stream_config, cert_path=None
+    )
+    mock_reader = AsyncMock()
+    mock_writer = AsyncMock()
+    mock_reader.read.return_value = b""
+
+    with patch(
+        "asyncio.open_connection", return_value=(mock_reader, mock_writer)
+    ) as mock_open:
+        res = await acq._connect_stream()
+
+    assert res == {"plain_tcp": True}
+    mock_open.assert_called_once_with("192.168.1.100", 2878, ssl=None)
+
+
+async def test_connect_stream_plain_tcp_banner_timeout_handled(mock_hass, stream_config):
+    """Kill mutant on L210: banner TimeoutError is ignored gracefully."""
+    stream_config["tls_config"] = {"enabled": False}
+    stream_config["request_pairing"] = {"port": 2878}
+
+    acq = GenericYamlTokenAcquirer(
+        mock_hass, "192.168.1.100", stream_config, cert_path=None
+    )
+    mock_reader = AsyncMock()
+    mock_writer = AsyncMock()
+    mock_reader.read.side_effect = TimeoutError()
+
+    with patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)):
+        res = await acq._connect_stream()
+
+    assert res == {"plain_tcp": True}
+    assert acq._reader is mock_reader
+
+
+async def test_connect_stream_plain_tcp_connection_error_raises_cannot_connect(
+    mock_hass, stream_config
+):
+    """Kill mutant on L213-217: plain TCP open_connection exception closes and raises CannotConnect."""
+    stream_config["tls_config"] = {"enabled": False}
+    stream_config["request_pairing"] = {"port": 2878}
+
+    acq = GenericYamlTokenAcquirer(
+        mock_hass, "192.168.1.100", stream_config, cert_path=None
+    )
+
+    with patch("asyncio.open_connection", side_effect=OSError("Network unreachable")):
+        with pytest.raises(CannotConnect) as exc_info:
+            await acq._connect_stream()
+
+    assert "Failed to connect via plain TCP to 192.168.1.100:2878: Network unreachable" in str(
+        exc_info.value
+    )
+    assert acq._reader is None
+    assert acq._writer is None
+
+
+async def test_connect_stream_plain_tcp_missing_config_keys_use_defaults(
+    mock_hass, stream_config
+):
+    """Kill L192 (req_cfg default {}→None), L193 (port default 2878→None),
+    L208 (buffer_size default 4096→None).
+
+    Remove 'request_pairing' and 'buffer_size' keys entirely from config.
+    The code must fall back to {} (so .get("port") works), 2878, and 4096.
+    If any default is mutated to None, the test fails:
+    - L192: None.get("port", 2878) → AttributeError
+    - L193: open_connection("ip", None) → wrong port
+    - L208: reader.read(None) → wrong buffer
+    """
+    stream_config["tls_config"] = {"enabled": False}
+    # Remove request_pairing entirely → req_cfg defaults to {}
+    stream_config.pop("request_pairing", None)
+    # Remove buffer_size entirely → defaults to 4096
+    stream_config.pop("buffer_size", None)
+
+    acq = GenericYamlTokenAcquirer(
+        mock_hass, "192.168.1.100", stream_config, cert_path=None
+    )
+    mock_reader = AsyncMock()
+    mock_writer = AsyncMock()
+    mock_reader.read.return_value = b""
+
+    with patch(
+        "asyncio.open_connection", return_value=(mock_reader, mock_writer)
+    ) as mock_open:
+        res = await acq._connect_stream()
+
+    assert res == {"plain_tcp": True}
+    # Kill L192 + L193: if req_cfg defaults to None, None.get() raises.
+    # If port defaults to None, open_connection gets wrong port.
+    mock_open.assert_called_once_with("192.168.1.100", 2878, ssl=None)
+    # Kill L208: if buffer_size defaults to None, read(None) is wrong.
+    mock_reader.read.assert_called_once_with(4096)
+


### PR DESCRIPTION
### Improvements & Network Resilience
- **3-Tier Dynamic ICMP Privilege Detection**: Added dynamic probe (`_can_use_icmp_privileged`) to automatically use raw ICMP sockets (`privileged=True`) in Home Assistant OS and container environments with root/`CAP_NET_RAW`, gracefully falling back to datagram sockets (`privileged=False`) for non-root users, and bypassing to direct TCP connection if OS policies restrict all ICMP sockets.
- **Hybrid Network Diagnostics & Telemetry**: Integrated hybrid ICMP diagnostics combining runtime polling telemetry (`last_runtime_check` capturing status, RTT, and socket tier from `YamlStatePoller` and `ConnectionSamsung2878`) with an on-demand live probe (`active_probe` with a responsive 1.0s timeout) when generating Home Assistant diagnostics bundles in `diagnostics.py`.
- **Global Network Diagnostics Registry**: Implemented `_LAST_NETWORK_DIAGNOSTICS` cache and `get_last_network_diagnostic()` in `helpers.py` ensuring telemetry availability across connection types while strictly complying with privacy redaction standards.

### Quality Assurance & Test Suite Hardening
- **Comprehensive Mutation Resistance**: Added targeted test suites (`test_config_flow__basics.py`, `test_token_acquirer_yaml__stream.py`, and `test_connection_intesisbox__yaml.py`) expanding test coverage to 1,533 passing tests with zero regressions.
- **Network & Diagnostics Coverage**: Full coverage for 3-tier ICMP detection, string slicing boundaries, unbracketed IPv6 addresses, and active/passive diagnostic payloads in `test_helpers__advanced.py` and `test_diagnostics.py`.
